### PR TITLE
shopify endpoints using official lib 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,15 +4,20 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ansi-regex": {
@@ -38,9 +43,9 @@
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.1"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -94,9 +99,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -105,25 +110,25 @@
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -140,14 +145,14 @@
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "source-map": {
@@ -164,9 +169,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-call-delegate": {
@@ -175,10 +180,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -187,10 +192,10 @@
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -199,9 +204,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -210,11 +215,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -223,8 +228,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -233,8 +238,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -243,8 +248,8 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -253,9 +258,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -264,11 +269,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -277,12 +282,12 @@
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "dev": true,
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -291,8 +296,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-messages": {
@@ -301,7 +306,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -310,7 +315,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -337,9 +342,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -348,7 +353,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -357,7 +362,7 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -366,11 +371,11 @@
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -379,15 +384,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -396,8 +401,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -406,7 +411,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -415,8 +420,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -425,7 +430,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -434,9 +439,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -445,7 +450,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -454,9 +459,9 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -465,10 +470,10 @@
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -477,9 +482,9 @@
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -488,9 +493,9 @@
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -499,8 +504,8 @@
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "dev": true,
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -509,12 +514,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -523,8 +528,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -533,7 +538,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -542,9 +547,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -553,7 +558,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -562,7 +567,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -571,9 +576,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -582,9 +587,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -593,7 +598,7 @@
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -602,8 +607,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-env": {
@@ -612,36 +617,36 @@
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "3.2.8",
-        "invariant": "2.2.4",
-        "semver": "5.5.0"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-register": {
@@ -650,13 +655,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.7",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "source-map": {
@@ -671,7 +676,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         }
       }
@@ -682,8 +687,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.7",
-        "regenerator-runtime": "0.11.1"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -692,11 +697,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -705,15 +710,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -722,10 +727,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -752,7 +757,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bn.js": {
@@ -767,7 +772,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -783,12 +788,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -797,9 +802,9 @@
       "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.2.0",
-        "browserify-des": "1.0.2",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -808,10 +813,10 @@
       "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "browserify-rsa": {
@@ -820,8 +825,8 @@
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sign": {
@@ -830,13 +835,13 @@
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.1",
-        "parse-asn1": "5.1.1"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -845,7 +850,7 @@
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
       "requires": {
-        "pako": "1.0.6"
+        "pako": "~1.0.5"
       }
     },
     "browserslist": {
@@ -854,8 +859,8 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000865",
-        "electron-to-chromium": "1.3.52"
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
       }
     },
     "buffer": {
@@ -864,9 +869,9 @@
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
-        "base64-js": "1.3.0",
-        "ieee754": "1.1.12",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -887,6 +892,27 @@
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        }
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30000865",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
@@ -904,11 +930,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "cipher-base": {
@@ -917,8 +943,16 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "^1.0.0"
       }
     },
     "co": {
@@ -931,7 +965,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
@@ -946,7 +980,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "constants-browserify": {
@@ -978,8 +1012,8 @@
       "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-hash": {
@@ -988,11 +1022,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.1",
-        "md5.js": "1.3.4",
-        "ripemd160": "2.0.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -1001,12 +1035,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.2.0",
-        "inherits": "2.0.1",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "crypto-browserify": {
@@ -1015,17 +1049,17 @@
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
       "dev": true,
       "requires": {
-        "browserify-cipher": "1.0.1",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.3",
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "diffie-hellman": "5.0.3",
-        "inherits": "2.0.1",
-        "pbkdf2": "3.0.16",
-        "public-encrypt": "4.0.2",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
       }
     },
     "dashdash": {
@@ -1033,7 +1067,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -1051,6 +1085,19 @@
         "ms": "2.0.0"
       }
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1062,8 +1109,8 @@
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "detect-indent": {
@@ -1072,7 +1119,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diffie-hellman": {
@@ -1081,9 +1128,9 @@
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "domain-browser": {
@@ -1097,13 +1144,18 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.0.0.tgz",
       "integrity": "sha512-FlWbnhgjtwD+uNLUGHbMykMOYQaTivdHEmYwAKFjn6GKe/CqY0fNae93ZHTd20snh9ZLr8mTzIL9m0APQ1pjQg=="
     },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "electron-to-chromium": {
@@ -1118,13 +1170,13 @@
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.5",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.1",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "escape-string-regexp": {
@@ -1134,9 +1186,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.0.65",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.65.tgz",
-      "integrity": "sha512-9sfOGvKCM5yszYMGSicv0A7dBDdQ4v5RUWGn3UH30ejI9kBTeSdbMMMW2fHBby2h/RYCCJS8UnKY2f5rBGv1sg=="
+      "version": "3.0.72",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.72.tgz",
+      "integrity": "sha512-xmh7Ay/71Wl41EPM3FVomp/GZKMgEGoo3x/qWdbGi+0DODbte+2l1sSXAiDKahBQn0zioG30ZNJTkxz08pEsMw=="
     },
     "esutils": {
       "version": "2.0.2",
@@ -1156,8 +1208,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.2"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "extend": {
@@ -1190,17 +1242,31 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "globals": {
@@ -1208,6 +1274,30 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
+    },
+    "got": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1219,8 +1309,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -1229,7 +1319,20 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
       }
     },
     "hash-base": {
@@ -1238,8 +1341,8 @@
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "hash.js": {
@@ -1248,8 +1351,8 @@
       "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.1"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       },
       "dependencies": {
         "inherits": {
@@ -1266,9 +1369,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.5",
-        "minimalistic-assert": "1.0.1",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "home-or-tmp": {
@@ -1277,18 +1380,23 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
     },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -1312,8 +1420,16 @@
     "inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-      "dev": true
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
     },
     "invariant": {
       "version": "2.2.4",
@@ -1321,7 +1437,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "1.4.0"
+        "loose-envify": "^1.0.0"
       }
     },
     "is-finite": {
@@ -1330,8 +1446,23 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1341,13 +1472,21 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -1366,6 +1505,11 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1399,11 +1543,18 @@
         "verror": "1.10.0"
       }
     },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -1411,8 +1562,13 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "md5.js": {
       "version": "1.3.4",
@@ -1420,8 +1576,8 @@
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.1"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "miller-rabin": {
@@ -1430,8 +1586,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime-db": {
@@ -1444,8 +1600,13 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -1465,7 +1626,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1500,29 +1661,39 @@
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.6",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.3",
-        "string_decoder": "1.1.1",
-        "timers-browserify": "2.0.10",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.4",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
+      }
+    },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -1535,6 +1706,11 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "os-browserify": {
       "version": "0.3.0",
@@ -1554,6 +1730,29 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
     "pako": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -1566,11 +1765,11 @@
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "dev": true,
       "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.2.0",
-        "create-hash": "1.2.0",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.16"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "path-browserify": {
@@ -1591,17 +1790,27 @@
       "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
       "dev": true,
       "requires": {
-        "create-hash": "1.2.0",
-        "create-hmac": "1.1.7",
-        "ripemd160": "2.0.2",
-        "safe-buffer": "5.1.2",
-        "sha.js": "2.4.11"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "private": {
       "version": "0.1.8",
@@ -1618,8 +1827,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-      "dev": true
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "public-encrypt": {
       "version": "4.0.2",
@@ -1627,11 +1835,11 @@
       "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
       "dev": true,
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.2.0",
-        "parse-asn1": "5.1.1",
-        "randombytes": "2.0.6"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "punycode": {
@@ -1643,6 +1851,16 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -1662,7 +1880,7 @@
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.1.0"
       }
     },
     "randomfill": {
@@ -1671,30 +1889,28 @@
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dev": true,
       "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.2"
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
       }
     },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       },
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         }
       }
     },
@@ -1722,9 +1938,9 @@
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regexpu-core": {
@@ -1733,9 +1949,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "regjsgen": {
@@ -1750,7 +1966,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       },
       "dependencies": {
         "jsesc": {
@@ -1767,7 +1983,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -1775,26 +1991,34 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      }
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "^1.0.0"
       }
     },
     "ripemd160": {
@@ -1803,8 +2027,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.1"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "safe-buffer": {
@@ -1835,25 +2059,25 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1",
-        "safe-buffer": "5.1.2"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "shadow-cljs": {
-      "version": "2.4.20",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.4.20.tgz",
-      "integrity": "sha512-K+nk9TB4DODrSgtcfhwTqX+0yPajG8ckbw2vSeM1sNe52uL22Yf77DODnAMDADET5RFEtdH1ytWcy+ty+UzXDw==",
+      "version": "2.4.22",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.4.22.tgz",
+      "integrity": "sha512-BOJDqMggUCFlgfABp480TpQlZUtG7/VTlfEGFwMSuGprwUPuE4VJtfRjCpZsh0H2xh6sA2Lnyxf7KWNFLga2Yg==",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.3",
-        "babel-preset-env": "1.7.0",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "readline-sync": "1.4.9",
+        "babel-core": "^6.26.0",
+        "babel-preset-env": "^1.6.0",
+        "mkdirp": "^0.5.1",
+        "node-libs-browser": "^2.0.0",
+        "readline-sync": "^1.4.7",
         "shadow-cljs-jar": "1.1.2",
-        "signal-exit": "3.0.2",
-        "source-map-support": "0.4.18",
-        "ws": "3.3.3"
+        "signal-exit": "^3.0.2",
+        "source-map-support": "^0.4.15",
+        "ws": "^3.0.0"
       },
       "dependencies": {
         "source-map": {
@@ -1868,7 +2092,7 @@
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "dev": true,
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "ws": {
@@ -1877,9 +2101,9 @@
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "dev": true,
           "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         }
       }
@@ -1889,6 +2113,17 @@
       "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.1.2.tgz",
       "integrity": "sha512-eyQQ4idGnN1gdLfZP4Eq2kKhC7QOW75jQN41w+yJziS5/m00lvcijM658ZkVMX5yoFrgTbIp0PDkHLXytX1icA==",
       "dev": true
+    },
+    "shopify-api-node": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/shopify-api-node/-/shopify-api-node-2.14.1.tgz",
+      "integrity": "sha512-jqB6W11wyfQh1E7Q0ko5gt1chbqaTxTWWo05uBjEW5ZI+LBi3UKHY8MMIbxDgD5levZeZWArErdvPpcSNVPfIA==",
+      "requires": {
+        "got": "^8.3.1",
+        "lodash": "^4.17.10",
+        "qs": "^6.5.2",
+        "stopcock": "^1.0.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -1902,6 +2137,14 @@
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
     },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1914,8 +2157,8 @@
       "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.1.0",
-        "source-map": "0.6.1"
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "sshpk": {
@@ -1923,16 +2166,21 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.2",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
       }
+    },
+    "stopcock": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stopcock/-/stopcock-1.0.0.tgz",
+      "integrity": "sha1-MUmvE+CTjwGQ6BheGBxKmuGMnOU="
     },
     "stream-browserify": {
       "version": "2.0.1",
@@ -1940,8 +2188,8 @@
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.6"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-http": {
@@ -1950,20 +2198,24 @@
       "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.1",
-        "readable-stream": "2.3.6",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1972,7 +2224,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -1981,13 +2233,18 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "timers-browserify": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
       "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
       "dev": true,
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "to-arraybuffer": {
@@ -2007,7 +2264,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "trim-right": {
@@ -2027,7 +2284,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -2060,6 +2317,19 @@
         }
       }
     },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
     "util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -2080,8 +2350,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
@@ -2093,9 +2362,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vm-browserify": {
@@ -2112,13 +2381,18 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
       "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "requires": {
-        "async-limiter": "1.0.0"
+        "async-limiter": "~1.0.0"
       }
     },
     "xmlhttprequest": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "xregexp": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.2.0.tgz",
+      "integrity": "sha512-IyMa7SVe9FyT4WbQVW3b95mTLVceHhLEezQ02+QMvmIqDnKTxk0MLWIQPSW2MXAr1zQb+9yvwYhcyQULneh3wA=="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -19,15 +19,16 @@
   "homepage": "https://github.com/degree9/enterprise#readme",
   "dependencies": {
     "dotenv": "^6.0.0",
-    "esm": "^3.0.61",
+    "esm": "^3.0.72",
     "node-fetch": "^2.1.2",
     "request": "^2.87.0",
     "shopify-api-node": "^2.14.1",
     "ws": "^5.2.2",
-    "xmlhttprequest": "^1.8.0"
+    "xmlhttprequest": "^1.8.0",
+    "xregexp": "^4.2.0"
   },
   "devDependencies": {
-    "shadow-cljs": "^2.4.20",
+    "shadow-cljs": "^2.4.22",
     "source-map-support": "^0.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "esm": "^3.0.61",
     "node-fetch": "^2.1.2",
     "request": "^2.87.0",
+    "shopify-api-node": "^2.14.1",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -18,6 +18,8 @@
   [com.cemerick/url "0.1.1"]
   [cljs-http "0.1.45"]
   [camel-snake-kebab "0.4.0"]
+  [com.taoensso/timbre "4.10.0"]
+  [binaryage/oops "0.6.2"]
 
   ; testing
   [thheller/shadow-cljs "2.4.13" :scope "test"]

--- a/src/degree9/shopify/core.cljs
+++ b/src/degree9/shopify/core.cljs
@@ -7,6 +7,7 @@
   oops.core
   degree9.env
   taoensso.timbre
+  degree9.shopify.products.product.spec
   [cljs.spec.alpha :as spec]))
 
 (defn -lib

--- a/src/degree9/shopify/core.cljs
+++ b/src/degree9/shopify/core.cljs
@@ -1,8 +1,43 @@
 (ns degree9.shopify.core
  (:require
+  ["shopify-api-node" :as shopify]
   ["request" :as request]
   degree9.shopify.auth.core
-  degree9.shopify.url.core))
+  degree9.shopify.url.core
+  oops.core
+  degree9.env
+  taoensso.timbre))
+
+(defn -lib
+ [shop-name auth]
+ (let [shop-name (or shop-name (degree9.env/get :shopify-host))
+       auth (or auth (degree9.shopify.auth.core/default-auth))
+       params
+       (clj->js
+        {:shopName shop-name
+         :apiKey (:degree9.shopify.auth/username auth)
+         :password (:degree9.shopify.auth/password auth)
+         ; @see https://help.shopify.com/en/api/getting-started/api-call-limit?ref=microapps
+         :autoLimit {:calls 2
+                     :interval 1000
+                     ; be conservative to avoid the 40 hard limit
+                     :bucketSize 35}})]
+  (shopify. params)))
+
+(def lib (memoize -lib))
+
+(defn api!'
+ [& {:keys [endpoint-method auth params shop-name]}]
+ (let [endpoint-method (or endpoint-method "")
+       promise
+       (oops.core/ocall+
+        (lib shop-name auth)
+        endpoint-method
+        (clj->js params))]
+  (-> promise
+   (.then #(prn (js->clj % :keywordize-keys true)))
+   (.catch #(taoensso.timbre/error %)))
+  promise))
 
 (defn body->clj
  [body]

--- a/src/degree9/shopify/core.cljs
+++ b/src/degree9/shopify/core.cljs
@@ -40,7 +40,7 @@
    (taoensso.timbre/error "response failed spec:" (spec/explain-str spec parsed)))))
 
 (defn api!
- [& {:keys [endpoint auth params shop-name spec]}]
+ [& {:keys [endpoint auth params shop-name spec input-spec]}]
  (let [endpoint (str endpoint)
        params (if (coll? params) (vec params) [params])
        promise
@@ -48,6 +48,13 @@
         (lib shop-name auth)
         endpoint
         (map clj->js params))]
+  (when input-spec
+   ; the input spec is only valid for write endpoints, so we only need to check
+   ; the first of the params.
+   (let [input (first params)]
+    (when-not
+     (spec/valid? input-spec input)
+     (taoensso.timbre/error "input failed spec:" (spec/explain-str input-spec input)))))
   (taoensso.timbre/debug "hitting endpoint:" endpoint)
   (-> promise
    (.then

--- a/src/degree9/shopify/core.cljs
+++ b/src/degree9/shopify/core.cljs
@@ -29,11 +29,12 @@
 (defn api!
  [& {:keys [endpoint auth params shop-name]}]
  (let [endpoint (str endpoint)
+       params (if (coll? params) (vec params) [params])
        promise
-       (oops.core/ocall+
+       (oops.core/oapply+
         (lib shop-name auth)
         endpoint
-        (clj->js params))]
+        (map clj->js params))]
   (-> promise
    (.then #(prn (js->clj % :keywordize-keys true)))
    (.catch #(taoensso.timbre/error %)))

--- a/src/degree9/shopify/discounts/code/spec.cljs
+++ b/src/degree9/shopify/discounts/code/spec.cljs
@@ -1,0 +1,18 @@
+(ns degree9.shopify.discounts.code
+ (:require
+  [cljs.spec.alpha :as spec]))
+
+(spec/def :degree9.shopify.discounts.discount/code string?)
+(spec/def :degree9.shopify.discounts.discount/amount :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.discounts.discount/type string?)
+
+(spec/def :degree9.shopify.discounts.discount/discount
+ (spec/keys
+  :req-un
+  [:degree9.shopify.discounts.discount/code
+   :degree9.shopify.discounts.discount/amount
+   :degree9.shopify.discounts.discount/type]))
+
+(spec/def :degree9.shopify.discounts.discount/discounts
+ (spec/coll-of
+  :degree9.shopify.discounts.discount/discount))

--- a/src/degree9/shopify/inventory/item/core.cljs
+++ b/src/degree9/shopify/inventory/item/core.cljs
@@ -1,0 +1,60 @@
+; implements the REST API for the InventoryItem resource
+; @see https://help.shopify.com/en/api/reference/inventory/inventoryitem
+(ns degree9.shopify.inventory.item
+ (:require
+  degree9.shopify.core))
+
+; Fetch all items
+;
+; A list of up to 100 `ids` in params is required.
+;
+; Also supports `page` and `limit` params.
+;
+; # Examples
+;
+; ```
+; (items! :params [{:ids [1234 2345]}]) ; fetches items 1234 and 2345
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/inventoryitem#index
+;
+(def items!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "inventoryItem.list"))
+
+; Fetch one item by ID
+;
+; # Examples
+;
+; ```
+; (item! :params [1234]) ; fetches item 1234
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/inventoryitem#show
+;
+(def item!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "inventoryItem.get"))
+
+; Update one item in place by ID
+;
+; # Examples
+;
+; ```
+; (update! :params [1234 {:sku "foo"}]) ; sets the sku to "foo" for 1234
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/inventoryitem#update
+;
+(def update!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "inventoryItem.update"))

--- a/src/degree9/shopify/inventory/item/core.cljs
+++ b/src/degree9/shopify/inventory/item/core.cljs
@@ -20,7 +20,7 @@
 ;
 ; - https://help.shopify.com/en/api/reference/inventory/inventoryitem#index
 ;
-(def items!
+(def list!
  (partial
   degree9.shopify.core/api!
   :endpoint "inventoryItem.list"))
@@ -37,7 +37,7 @@
 ;
 ; - https://help.shopify.com/en/api/reference/inventory/inventoryitem#show
 ;
-(def item!
+(def get!
  (partial
   degree9.shopify.core/api!
   :endpoint "inventoryItem.get"))

--- a/src/degree9/shopify/inventory/location/core.cljs
+++ b/src/degree9/shopify/inventory/location/core.cljs
@@ -29,23 +29,22 @@
 
 ; Fetch a single location
 ; @see https://help.shopify.com/en/api/reference/inventory/location#show
-(defn location!
- [id & {:keys [auth callback params]}]
- {:pre [(spec/valid? :degree9.shopify.inventory.location/id id)]
-  :post [(location? (:location %))]}
- (let [endpoint (str "/admin/locations/" id ".json")]
-  (degree9.shopify.core/api!
-   :endpoint endpoint
-   :auth auth
-   :callback callback
-   :params params)))
+(def location!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "location.get"))
 
 ; Fetch the total locations count
 ; @see https://help.shopify.com/en/api/reference/inventory/location#count
-(def count!
- (partial
-  degree9.shopify.core/api!
-  :endpoint "location.count"))
+; @see https://help.shopify.com/en/api/reference/inventory/location#count
+;
+; @TODO missing in upstream lib
+; @see https://github.com/degree9/enterprise/issues/14
+;
+; (def count!
+;  (partial
+;   degree9.shopify.core/api!
+;   :endpoint "location.count"))
 
 ; Fetch the inventory levels for a location
 ; Note: Requires `read_inventory` scope
@@ -54,15 +53,14 @@
 ;       only be read/write through the API.
 ;       @see https://help.shopify.com/en/api/guides/inventory-migration-guide
 ; @see https://help.shopify.com/en/api/reference/inventory/location#inventory_levels
-(defn inventory-levels!
- [id & {:keys [auth params shop-name]}]
- {:pre [(spec/valid? :degree9.shopify.inventory.location/id id)]}
- (let [endpoint (str "locations/" id "/inventory_levels.json")]
-  (degree9.shopify.core/api!
-   :endpoint endpoint
-   :auth auth
-   :callback callback
-   :params params)))
+;
+; @TODO missing in upstream lib
+; @see https://github.com/degree9/enterprise/issues/15
+;
+; (def inventory-levels!
+;  (partial
+;   degree9.shopify.core/api!
+;   :endpoint "location.inventory-levels"))
 
 ; TESTS
 

--- a/src/degree9/shopify/inventory/location/core.cljs
+++ b/src/degree9/shopify/inventory/location/core.cljs
@@ -25,7 +25,7 @@
 (def locations!
  (partial
   degree9.shopify.core/api!
-  :endpoint "/admin/locations.json"))
+  :endpoint "location.list"))
 
 ; Fetch a single location
 ; @see https://help.shopify.com/en/api/reference/inventory/location#show
@@ -45,7 +45,7 @@
 (def count!
  (partial
   degree9.shopify.core/api!
-  :endpoint "/admin/locations/count.json"))
+  :endpoint "location.count"))
 
 ; Fetch the inventory levels for a location
 ; Note: Requires `read_inventory` scope
@@ -55,9 +55,9 @@
 ;       @see https://help.shopify.com/en/api/guides/inventory-migration-guide
 ; @see https://help.shopify.com/en/api/reference/inventory/location#inventory_levels
 (defn inventory-levels!
- [id & {:keys [auth callback params]}]
+ [id & {:keys [auth params shop-name]}]
  {:pre [(spec/valid? :degree9.shopify.inventory.location/id id)]}
- (let [endpoint (str "/admin/locations/" id "/inventory_levels.json")]
+ (let [endpoint (str "locations/" id "/inventory_levels.json")]
   (degree9.shopify.core/api!
    :endpoint endpoint
    :auth auth

--- a/src/degree9/shopify/inventory/location/core.cljs
+++ b/src/degree9/shopify/inventory/location/core.cljs
@@ -32,7 +32,7 @@
 ;
 ; - https://help.shopify.com/en/api/reference/inventory/location#index
 ;
-(def locations!
+(def list!
  (partial
   degree9.shopify.core/api!
   :endpoint "location.list"))
@@ -49,7 +49,7 @@
 ;
 ; - https://help.shopify.com/en/api/reference/inventory/location#show
 ;
-(def location!
+(def get!
  (partial
   degree9.shopify.core/api!
   :endpoint "location.get"))

--- a/src/degree9/shopify/inventory/location/core.cljs
+++ b/src/degree9/shopify/inventory/location/core.cljs
@@ -8,18 +8,6 @@
   [cljs.spec.alpha :as spec]
   [cljs.test :refer-macros [deftest is]]))
 
-(defn location?
- [maybe-location]
- (spec/valid?
-  :degree9.shopify.inventory.location/location
-  maybe-location))
-
-(defn locations?
- [maybe-locations]
- (spec/valid?
-  :degree9.shopify.inventory.location/locations
-  maybe-locations))
-
 ; Fetch all locations
 ;
 ; # Examples
@@ -35,7 +23,8 @@
 (def list!
  (partial
   degree9.shopify.core/api!
-  :endpoint "location.list"))
+  :endpoint "location.list"
+  :spec :degree9.shopify.inventory.location/locations))
 
 ; Fetch a single location by ID
 ;
@@ -52,7 +41,8 @@
 (def get!
  (partial
   degree9.shopify.core/api!
-  :endpoint "location.get"))
+  :endpoint "location.get"
+  :spec :degree9.shopify.inventory.location/location))
 
 ; Fetch the total locations count
 ;
@@ -68,6 +58,7 @@
 ;  (partial
 ;   degree9.shopify.core/api!
 ;   :endpoint "location.count"))
+;   :spec :degree9.shopify/count
 
 ; Fetch the inventory levels for a location
 ;

--- a/src/degree9/shopify/inventory/location/core.cljs
+++ b/src/degree9/shopify/inventory/location/core.cljs
@@ -21,22 +21,45 @@
   maybe-locations))
 
 ; Fetch all locations
-; @see https://help.shopify.com/en/api/reference/inventory/location#index
+;
+; # Examples
+;
+; ```
+; (locations!) ; fetches all locations
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/location#index
+;
 (def locations!
  (partial
   degree9.shopify.core/api!
   :endpoint "location.list"))
 
-; Fetch a single location
-; @see https://help.shopify.com/en/api/reference/inventory/location#show
+; Fetch a single location by ID
+;
+; # Examples
+;
+; ```
+; (location! :params [1234]) ; fetches location with ID 1234
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/location#show
+;
 (def location!
  (partial
   degree9.shopify.core/api!
   :endpoint "location.get"))
 
 ; Fetch the total locations count
-; @see https://help.shopify.com/en/api/reference/inventory/location#count
-; @see https://help.shopify.com/en/api/reference/inventory/location#count
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/location#count
+; - https://help.shopify.com/en/api/reference/inventory/location#count
 ;
 ; @TODO missing in upstream lib
 ; @see https://github.com/degree9/enterprise/issues/14
@@ -47,12 +70,16 @@
 ;   :endpoint "location.count"))
 
 ; Fetch the inventory levels for a location
+;
 ; Note: Requires `read_inventory` scope
 ; Note: API only!
 ;       looks like location inventories are NOT available in the web UI and can
 ;       only be read/write through the API.
 ;       @see https://help.shopify.com/en/api/guides/inventory-migration-guide
-; @see https://help.shopify.com/en/api/reference/inventory/location#inventory_levels
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/inventory/location#inventory_levels)
 ;
 ; @TODO missing in upstream lib
 ; @see https://github.com/degree9/enterprise/issues/15

--- a/src/degree9/shopify/inventory/location/spec.cljs
+++ b/src/degree9/shopify/inventory/location/spec.cljs
@@ -1,14 +1,12 @@
 (ns degree9.shopify.inventory.location.spec
  (:require
+  degree9.shopify.spec
   [cljs.spec.alpha :as spec]))
 
-(spec/def :degree9.shopify.inventory.location/id pos-int?)
-
-(spec/def :degree9.shopify.inventory.location/admin_graphql_api_id string?)
 (spec/def :degree9.shopify.inventory.location/province_code
  (spec/nilable string?))
 (spec/def :degree9.shopify.inventory.location/phone string?)
-(spec/def :degree9.shopify.inventory.location/name string?)
+(spec/def :degree9.shopify.inventory.location/name :degree9.shopify/title)
 (spec/def :degree9.shopify.inventory.location/city string?)
 (spec/def :degree9.shopify.inventory.location/address1 string?)
 (spec/def :degree9.shopify.inventory.location/updated_at string?)
@@ -16,30 +14,29 @@
 (spec/def :degree9.shopify.inventory.location/country_name string?)
 (spec/def :degree9.shopify.inventory.location/address2 string?)
 (spec/def :degree9.shopify.inventory.location/zip string?)
-(spec/def :degree9.shopify.inventory.location/id pos-int?)
 (spec/def :degree9.shopify.inventory.location/legacy boolean?)
 (spec/def :degree9.shopify.inventory.location/province string?)
 (spec/def :degree9.shopify.inventory.location/country string?)
-(spec/def :degree9.shopify.inventory.location/created_at string?)
 
 (spec/def :degree9.shopify.inventory.location/location
  (spec/keys
-  :req-un [:degree9.shopify.inventory.location/admin_graphql_api_id
+  :req-un [:degree9.shopify/admin_graphql_api_id
+           :degree9.shopify/id
+           :degree9.shopify/created_at
+           :degree9.shopify/updated_at
+
+           :degree9.shopify.location/name
            :degree9.shopify.inventory.location/province_code
            :degree9.shopify.inventory.location/phone
-           :degree9.shopify.loation/name
            :degree9.shopify.inventory.location/city
            :degree9.shopify.inventory.location/address1
-           :degree9.shopify.inventory.location/updated_at
            :degree9.shopify.inventory.location/country_code
            :degree9.shopify.inventory.location/country_name
            :degree9.shopify.inventory.location/address2
            :degree9.shopify.inventory.location/zip
-           :degree9.shopify.inventory.location/id
            :degree9.shopify.inventory.location/legacy
            :degree9.shopify.inventory.location/province
-           :degree9.shopify.inventory.location/country
-           :degree9.shopify.inventory.location/created_at]))
+           :degree9.shopify.inventory.location/country]))
 
 (spec/def :degree9.shopify.inventory.location/locations
  (spec/coll-of

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -24,3 +24,25 @@
   degree9.shopify.core/api!
   :endpoint "order.list"
   :spec :degree9.shopify.orders.order/orders))
+
+; Get an order by order ID
+;
+; Accepts a single optional parameter `fields` to filter returned fields.
+;
+; # Examples
+;
+; ```
+; (get! :params [639742640171]) ; returns entire order object
+; (get! :params [639742640171 {:fields [:created_at]}]) ; returns {:created_at "2018-07-25T04:03:36-04:00"}
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#show
+;
+(def get!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.get"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.orders.order/order))

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -1,0 +1,26 @@
+; implements the REST API for the Order resource
+; https://help.shopify.com/en/api/reference/orders/order
+(ns degree9.shopify.orders.order.core
+ (:require
+  degree9.shopify.core
+  degree9.shopify.orders.order.spec))
+
+; List all orders
+;
+; Accepts many parameters for filtering, see Shopify docs
+;
+; # Examples
+;
+; ```
+; (list!) ; lists all orders
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#index
+;
+(def list!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.list"
+  :spec :degree9.shopify.orders.order/orders))

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -86,7 +86,8 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "order.close"
-  :input-spec :degree9.shopify/id))
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.orders.order/order))
 
 ; Open an order by ID
 ;
@@ -106,4 +107,37 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "order.open"
-  :input-spec :degree9.shopify/id))
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.orders.order/order))
+
+; Cancel an order by ID
+;
+; Orders that have a fulfillment object can't be canceled.
+; Needs order write permissions.
+; Has several params important params, duplicated from docs here.
+;
+; - `amount`: The amount to refund. If set, Shopify attempts to void or refund
+;             the payment, depending on its status.
+; - `restock`: Whether to restock refunded items back to your store's inventory.
+; - `reason`: The reason for the order cancellation. Valid values: customer,
+;             inventory, fraud, declined, and other.
+; - `email`: Whether to send an email to the customer notifying them of the
+;            cancellation.
+; - `refund`: The refund transactions to perform. Required for some more complex
+;             refund situations. For more information, see the Refund API.
+;
+; # Examples
+; ```
+; (cancel! :params [639742640171 {:amount 50}]) ; returns the canceled order
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#cancel
+;
+(def cancel!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.cancel"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.orders.order/order))

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -127,6 +127,7 @@
 ;             refund situations. For more information, see the Refund API.
 ;
 ; # Examples
+;
 ; ```
 ; (cancel! :params [639742640171 {:amount 50}]) ; returns the canceled order
 ; ```
@@ -140,4 +141,38 @@
   degree9.shopify.core/api!
   :endpoint "order.cancel"
   :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.orders.order/order))
+
+; Create an order
+;
+; Needs order write permissions.
+; At least one line item is required.
+; Takes additional params to the order fields.
+;
+; - `send_receipt`: Whether to send an order confirmation to the customer.
+; - `send_fulfillment_receipt`: Whether to send a shipping confirmation to the
+;                               customer.
+; - `inventory_behaviour`: The behaviour to use when updating inventory.
+;                          (default: bypass)
+;   - `bypass`: Do not claim inventory.
+;   - `decrement_ignoring_policy`: Ignore the product's inventory policy and
+;                                  claim amounts no matter what.
+;   - `decrement_obeying_policy`: Obey the product's inventory policy.
+;
+; # Examples
+;
+; ```
+; ; creates and returns an order
+; (create! :params [{:line_items [{:variant_id 12891968536619 :quantity 1}]}])
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#create
+;
+(def create!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.create"
+  :input-spec :degree9.shopify.orders.order/order
   :spec :degree9.shopify.orders.order/order))

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -46,3 +46,24 @@
   :endpoint "order.get"
   :input-spec :degree9.shopify/id
   :spec :degree9.shopify.orders.order/order))
+
+; Fetch the total orders count
+;
+; Accepts several parameters for filtering what is counted, see Shopify docs
+;
+; # Examples
+;
+; ```
+; (count!) ; count all orders
+; (count! :params [{:status "open"}]) ; count all open orders
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#count
+;
+(def count!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.count"
+  :spec :degree9.shopify/count))

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -2,6 +2,7 @@
 ; https://help.shopify.com/en/api/reference/orders/order
 (ns degree9.shopify.orders.order.core
  (:require
+  degree9.shopify.spec
   degree9.shopify.core
   degree9.shopify.orders.order.spec))
 
@@ -176,3 +177,46 @@
   :endpoint "order.create"
   :input-spec :degree9.shopify.orders.order/order
   :spec :degree9.shopify.orders.order/order))
+
+; Updates an order by order ID
+;
+; Needs order write permissions.
+;
+; # Examples
+;
+; ```
+; ; updates 639784583211 and returns the order with a note
+; (update! :params [639784583211 {:note "Hi!"}])
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#update
+;
+(def update!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.update"
+  :input-spec [:degree9.shopify/id :degree9.shopify.orders.order/order]
+  :spec :degree9.shopify.orders.order/order))
+
+; Deletes an order by order ID
+;
+; Needs order write permissions.
+;
+; # Examples
+;
+; ```
+; (delete! :params [639784583211]) ; deletes order 639784583211, no return
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#destroy
+;
+(def delete!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.delete"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify/empty-api-response))

--- a/src/degree9/shopify/orders/order/core.cljs
+++ b/src/degree9/shopify/orders/order/core.cljs
@@ -32,7 +32,7 @@
 ; # Examples
 ;
 ; ```
-; (get! :params [639742640171]) ; returns entire order object
+; (get! :params [639742640171]) ; returns entire order
 ; (get! :params [639742640171 {:fields [:created_at]}]) ; returns {:created_at "2018-07-25T04:03:36-04:00"}
 ; ```
 ;
@@ -67,3 +67,43 @@
   degree9.shopify.core/api!
   :endpoint "order.count"
   :spec :degree9.shopify/count))
+
+; Close an order by ID
+;
+; Needs order write permissions.
+;
+; # Examples
+;
+; ```
+; (close! :params [639742640171]) ; returns the closed order
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#close
+;
+(def close!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.close"
+  :input-spec :degree9.shopify/id))
+
+; Open an order by ID
+;
+; Needs order write permissions.
+;
+; # Examples
+;
+; ```
+; (open! :params [639742640171]) ; returns the opened order
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/orders/order#open
+;
+(def open!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "order.open"
+  :input-spec :degree9.shopify/id))

--- a/src/degree9/shopify/orders/order/spec.cljs
+++ b/src/degree9/shopify/orders/order/spec.cljs
@@ -55,8 +55,8 @@
 (spec/def :degree9.shopify.orders.order/total_price_usd :degree9.shopify/monetary_amount)
 (spec/def :degree9.shopify.orders.order/checkout_token (spec/nilable :degree9.shopify/token))
 (spec/def :degree9.shopify.orders.order/reference (spec/nilable string?))
-(spec/def :degree9.shopify.orders.order/user_id :degree9.shopify/id)
-(spec/def :degree9.shopify.orders.order/location_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/user_id (spec/nilable :degree9.shopify/id))
+(spec/def :degree9.shopify.orders.order/location_id (spec/nilable :degree9.shopify/id))
 (spec/def :degree9.shopify.orders.order/source_identifier (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/source_url (spec/nilable :degree9.shopify/url))
 (spec/def :degree9.shopify.orders.order/processed_at (spec/nilable :degree9.shopify/time))
@@ -189,7 +189,6 @@
 (spec/def :degree9.shopify.orders.order/service string?)
 (spec/def :degree9.shopify.orders.order/tracking_company (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/shipment_status (spec/nilable string?))
-(spec/def :degree9.shopify.orders.order/location_id :degree9.shopify/id)
 (spec/def :degree9.shopify.orders.order/tracking_number string?)
 (spec/def :degree9.shopify.orders.order/tracking_numbers
  (spec/coll-of

--- a/src/degree9/shopify/orders/order/spec.cljs
+++ b/src/degree9/shopify/orders/order/spec.cljs
@@ -41,7 +41,7 @@
 (spec/def :degree9.shopify.orders.order/total_weight :degree9.shopify/weight)
 (spec/def :degree9.shopify.orders.order/total_tax :degree9.shopify/monetary_amount)
 (spec/def :degree9.shopify.orders.order/taxes_included boolean?)
-(spec/def :degree9.shopify.orders.order/financial_status string?)
+(spec/def :degree9.shopify.orders.order/financial_status #{"authorized" "pending" "paid" "refunded" "voided"})
 (spec/def :degree9.shopify.orders.order/confirmed boolean?)
 (spec/def :degree9.shopify.orders.order/total_discounts :degree9.shopify/monetary_amount)
 (spec/def :degree9.shopify.orders.order/total_line_items_price :degree9.shopify/monetary_amount)
@@ -79,7 +79,7 @@
 (spec/def :degree9.shopify.orders.order/processing_method string?)
 (spec/def :degree9.shopify.orders.order/checkout_id (spec/nilable :degree9.shopify/id))
 (spec/def :degree9.shopify.orders.order/source_name string?)
-(spec/def :degree9.shopify.orders.order/fulfillment_status (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/fulfillment_status (spec/nilable #{"shipped" "partial" "unshipped"}))
 
 ; tax lines
 
@@ -185,7 +185,7 @@
 (spec/def :degree9.shopify.orders.order/shipping_address :degree9.shopify.address/address)
 
 (spec/def :degree9.shopify.orders.order/order_id :degree9.shopify/id)
-(spec/def :degree9.shopify.orders.order/status string?)
+(spec/def :degree9.shopify.orders.order/status #{"open" "closed"})
 (spec/def :degree9.shopify.orders.order/service string?)
 (spec/def :degree9.shopify.orders.order/tracking_company (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/shipment_status (spec/nilable string?))

--- a/src/degree9/shopify/orders/order/spec.cljs
+++ b/src/degree9/shopify/orders/order/spec.cljs
@@ -1,0 +1,256 @@
+(ns degree9.shopify.orders.order.spec
+ (:require
+  degree9.shopify.spec
+  degree9.shopify.discounts.code
+  [cljs.spec.alpha :as spec]))
+
+(spec/def :degree9.shopify.orders.order.discount/type string?)
+(spec/def :degree9.shopify.orders.order.discount/value string?)
+(spec/def :degree9.shopify.orders.order.discount/value_type string?)
+(spec/def :degree9.shopify.orders.order.discount/allocation_method string?)
+(spec/def :degree9.shopify.orders.order.discount/target_selection string?)
+(spec/def :degree9.shopify.orders.order.discount/target_type string?)
+(spec/def :degree9.shopify.orders.order.discount/code :degree9.shopify.discounts.discount/code)
+
+(spec/def :degree9.shopify.orders.order.discount/discount
+ (spec/keys
+  :req-un
+  [:degree9.shopify.orders.order.discount/type
+   :degree9.shopify.orders.order.discount/value
+   :degree9.shopify.orders.order.discount/value_type
+   :degree9.shopify.orders.order.discount/allocation_method
+   :degree9.shopify.orders.order.discount/target_selection
+   :degree9.shopify.orders.order.discount/target_type
+   :degree9.shopify.orders.order.discount/code]))
+
+(spec/def :degree9.shopify.orders.order.discount/discounts
+ (spec/coll-of
+  :degree9.shopify.orders.order.discount/discount))
+(spec/def :degree9.shopify.orders.order/discount_applications :degree9.shopify.orders.order.discount/discounts)
+
+(spec/def :degree9.shopify.orders.order/discount_codes :degree9.shopify.orders.order.discount/discounts)
+
+(spec/def :degree9.shopify.orders.order/closed_at (spec/nilable :degree9.shopify/time))
+(spec/def :degree9.shopify.orders.order/number nat-int?)
+(spec/def :degree9.shopify.orders.order/note (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/token :degree9.shopify/token)
+(spec/def :degree9.shopify.orders.order/gateway string?)
+(spec/def :degree9.shopify.orders.order/test boolean?)
+(spec/def :degree9.shopify.orders.order/total_price :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/subtotal_price :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/total_weight :degree9.shopify/weight)
+(spec/def :degree9.shopify.orders.order/total_tax :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/taxes_included boolean?)
+(spec/def :degree9.shopify.orders.order/financial_status string?)
+(spec/def :degree9.shopify.orders.order/confirmed boolean?)
+(spec/def :degree9.shopify.orders.order/total_discounts :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/total_line_items_price :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/cart_token :degree9.shopify/token)
+(spec/def :degree9.shopify.orders.order/buyer_accepts_marketing boolean?)
+(spec/def :degree9.shopify.orders.order/name string?)
+(spec/def :degree9.shopify.orders.order/referring_site :degree9.shopify/url)
+(spec/def :degree9.shopify.orders.order/landing_site :degree9.shopify/url)
+(spec/def :degree9.shopify.orders.order/cancelled_at (spec/nilable :degree9.shopify/time))
+(spec/def :degree9.shopify.orders.order/cancel_reason (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/total_price_usd :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/checkout_token :degree9.shopify/token)
+(spec/def :degree9.shopify.orders.order/reference string?)
+(spec/def :degree9.shopify.orders.order/user_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/location_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/source_identifier string?)
+(spec/def :degree9.shopify.orders.order/source_url (spec/nilable :degree9.shopify/url))
+(spec/def :degree9.shopify.orders.order/processed_at (spec/nilable :degree9.shopify/time))
+(spec/def :degree9.shopify.orders.order/device_id (spec/nilable :degree9.shopify/id))
+(spec/def :degree9.shopify.orders.order/customer_locale (spec/nilable :degree9.shopify/locale))
+(spec/def :degree9.shopify.orders.order/app_id (spec/nilable :degree9.shopify/id))
+(spec/def :degree9.shopify.orders.order/browser_ip (spec/nilable :degree9.shopify/ip))
+(spec/def :degree9.shopify.orders.order/landing_site_ref string?)
+(spec/def :degree9.shopify.orders.order/order_number :degree9.shopify/id)
+
+(spec/def :degree9.shopify.orders.order/note_attributes
+ (spec/coll-of
+  :degree9.shopify/attribute))
+
+(spec/def :degree9.shopify.orders.order/payment_gateway_name string?)
+(spec/def :degree9.shopify.orders.order/payment_gateway_names
+ (spec/coll-of
+  :degree9.shopify.orders.order/payment_gateway_name))
+
+(spec/def :degree9.shopify.orders.order/processing_method string?)
+(spec/def :degree9.shopify.orders.order/checkout_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/source_name string?)
+(spec/def :degree9.shopify.orders.order/fulfillment_status (spec/nilable string?))
+
+; tax lines
+
+(spec/def :degree9.shopify.orders.order/price :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/rate number?)
+(spec/def :degree9.shopify.orders.order/title :degree9.shopify/title)
+(spec/def :degree9.shopify.orders.order/tax_line
+ (spec/keys
+  :req-un
+  [:degree9.shopify.orders.order/price
+   :degree9.shopify.orders.order/rate
+   :degree9.shopify.orders.order/title]))
+(spec/def :degree9.shopify.orders.order/tax_lines
+ (spec/coll-of
+  :degree9.shopify.orders.order/tax_line))
+
+(spec/def :degree9.shopify.orders.order/contact_email :degree9.shopify/email)
+(spec/def :degree9.shopify.orders.order/order_status_url :degree9.shopify/url)
+
+; line items
+
+(spec/def :degree9.shopify.orders.order/variant_id :degree9.shopify.products.variant/id)
+(spec/def :degree9.shopify.orders.order/variant_title :degree9.shopify.products.variant/title)
+(spec/def :degree9.shopify.orders.order/product_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/taxable boolean?)
+(spec/def :degree9.shopify.orders.order/gift_card boolean?)
+(spec/def :degree9.shopify.orders.order/name :degree9.shopify/title)
+(spec/def :degree9.shopify.orders.order/variant_inventory_management string?)
+(spec/def :degree9.shopify.orders.order/properties
+ (spec/coll-of
+  :degree9.shopify/attribute))
+(spec/def :degree9.shopify.orders.order/product_exists boolean?)
+(spec/def :degree9.shopify.orders.order/fulfillable_quantity :degree9.shopify/quantity)
+(spec/def :degree9.shopify.orders.order/grams :degree9.shopify/weight)
+(spec/def :degree9.shopify.orders.order/total_discount :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify.orders.order/fulfillment_status (spec/nilable string?))
+; @TODO are discount allocations and applications the same thing?
+(spec/def :degree9.shopify.orders.order/discount_allocations :degree9.shopify.orders.order/discount_applications)
+
+(spec/def :degree9.shopify.orders.order/line_item
+ (spec/keys
+  :req-un
+  [:degree9.shopify/id
+   :degree9.shopify/title
+   :degree9.shopify/quantity
+   :degree9.shopify/price
+   :degree9.shopify/sku
+   :degree9.shopify/vendor
+   :degree9.shopify/fulfillment_service
+   :degree9.shopify/admin_graphql_api_id
+
+   :degree9.shopify.orders.order/variant_id
+   :degree9.shopify.orders.order/variant_title
+   :degree9.shopify.orders.order/product_id
+   :degree9.shopify.orders.order/taxable
+   :degree9.shopify.orders.order/gift_card
+   :degree9.shopify.orders.order/name
+   :degree9.shopify.orders.order/variant_inventory_management
+   :degree9.shopify.orders.order/properties
+   :degree9.shopify.orders.order/product_exists
+   :degree9.shopify.orders.order/fulfillable_quantity
+   :degree9.shopify.orders.order/grams
+   :degree9.shopify.orders.order/total_discount
+   :degree9.shopify.orders.order/fulfillment_status
+   :degree9.shopify.orders.order/discount_allocations
+   :degree9.shopify.orders.order/tax_lines]))
+
+(spec/def :degree9.shopify.orders.order/line_items
+ (spec/coll-of
+  :degree9.shopify.orders.order/line_item))
+
+; shipping items
+
+(spec/def :degree9.shopify.orders.order/code string?)
+(spec/def :degree9.shopify.orders.order/source string?)
+(spec/def :degree9.shopify.orders.order/phone (spec/nilable :degree9.shopify/phone))
+(spec/def :degree9.shopify.orders.order/requested_fulfillment_service_id (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/delivery_category (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/carrier_identifier (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/discounted_price :degree9.shopify/price)
+
+(spec/def :degree9.shopify.orders.order/shipping_line
+ (spec/keys
+  :req-un
+  [:degree9.shopify/id
+   :degree9.shopify/title
+   :degree9.shopify/price
+
+   :degree9.shopify.orders.order/code
+   :degree9.shopify.orders.order/source
+   :degree9.shopify.orders.order/phone
+   :degree9.shopify.orders.order/requested_fulfillment_service_id
+   :degree9.shopify.orders.order/delivery_category
+   :degree9.shopify.orders.order/carrier_identifier
+   :degree9.shopify.orders.order/discounted_price
+   :degree9.shopify.orders.order/discount_allocations
+   :degree9.shopify.orders.order/tax_lines]))
+(spec/def :degree9.shopify.orders.order/shipping_lines
+ (spec/coll-of
+  :degree9.shopify.orders.order/shipping_line))
+
+(spec/def :degree9.shopify.orders.order/order
+ (spec/keys
+  ; optional keys to support `fields` filtering
+  :opt-un
+  [:degree9.shopify/id
+   :degree9.shopify/email
+   :degree9.shopify/created_at
+   :degree9.shopify/updated_at
+   :degree9.shopify/currency
+   :degree9.shopify/phone
+   :degree9.shopify/tags
+   :degree9.shopify/admin_graphql_api_id
+
+   :degree9.shopify.orders.order/closed_at
+   :degree9.shopify.orders.order/number
+   :degree9.shopify.orders.order/note
+   :degree9.shopify.orders.order/token
+   :degree9.shopify.orders.order/gateway
+   :degree9.shopify.orders.order/test
+   :degree9.shopify.orders.order/total_price
+   :degree9.shopify.orders.order/subtotal_price
+   :degree9.shopify.orders.order/total_weight
+   :degree9.shopify.orders.order/total_tax
+   :degree9.shopify.orders.order/taxes_included
+   :degree9.shopify.orders.order/financial_status
+   :degree9.shopify.orders.order/confirmed
+   :degree9.shopify.orders.order/total_discounts
+   :degree9.shopify.orders.order/total_line_items_price
+   :degree9.shopify.orders.order/cart_token
+   :degree9.shopify.orders.order/buyer_accepts_marketing
+   :degree9.shopify.orders.order/name
+   :degree9.shopify.orders.order/referring_site
+   :degree9.shopify.orders.order/landing_site
+   :degree9.shopify.orders.order/cancelled_at
+   :degree9.shopify.orders.order/cancel_reason
+   :degree9.shopify.orders.order/total_price_usd
+   :degree9.shopify.orders.order/checkout_token
+   :degree9.shopify.orders.order/reference
+   :degree9.shopify.orders.order/user_id
+   :degree9.shopify.orders.order/location_id
+   :degree9.shopify.orders.order/source_identifier
+   :degree9.shopify.orders.order/source_url
+   :degree9.shopify.orders.order/processed_at
+   :degree9.shopify.orders.order/device_id
+   :degree9.shopify.orders.order/customer_locale
+   :degree9.shopify.orders.order/app_id
+   :degree9.shopify.orders.order/browser_ip
+   :degree9.shopify.orders.order/landing_site_ref
+   :degree9.shopify.orders.order/order_number
+
+   :degree9.shopify.orders.order/discount_applications
+   :degree9.shopify.orders.order/discount_codes
+
+   :degree9.shopify.orders.order/note_attributes
+
+   :degree9.shopify.orders.order/payment_gateway_names
+
+   :degree9.shopify.orders.order/processing_method
+   :degree9.shopify.orders.order/checkout_id
+   :degree9.shopify.orders.order/source_name
+   :degree9.shopify.orders.order/fulfillment_status
+
+   :degree9.shopify.orders.order/tax_lines
+
+   :degree9.shopify.orders.order/contact_email
+   :degree9.shopify.orders.order/order_status_url
+
+   :degree9.shopify.orders.order/line_items
+   :degree9.shopify.orders.order/shipping_lines]))
+
+(spec/def :degree9.shopify.orders.order/orders
+ (spec/coll-of
+  :degree9.shopify.orders.order/order))

--- a/src/degree9/shopify/orders/order/spec.cljs
+++ b/src/degree9/shopify/orders/order/spec.cljs
@@ -181,6 +181,58 @@
  (spec/coll-of
   :degree9.shopify.orders.order/shipping_line))
 
+(spec/def :degree9.shopify.orders.order/billing_address :degree9.shopify.address/address)
+(spec/def :degree9.shopify.orders.order/shipping_address :degree9.shopify.address/address)
+
+(spec/def :degree9.shopify.orders.order/order_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/status string?)
+(spec/def :degree9.shopify.orders.order/service string?)
+(spec/def :degree9.shopify.orders.order/tracking_company (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/shipment_status (spec/nilable string?))
+(spec/def :degree9.shopify.orders.order/location_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/tracking_number string?)
+(spec/def :degree9.shopify.orders.order/tracking_numbers
+ (spec/coll-of
+  :degree9.shopify.orders.order/tracking_number))
+(spec/def :degree9.shopify.orders.order/tracking_url :degree9.shopify/url)
+(spec/def :degree9.shopify.orders.order/tracking_urls
+ (spec/coll-of
+  :degree9.shopify.orders.order/tracking_url))
+
+(spec/def :degree9.shopify.order.order.fulfilment.receipt/testcase boolean?)
+(spec/def :degree9.shopify.order.order.fulfilment.receipt/authorization string?)
+(spec/def :degree9.shopify.order.order.fulfilment.receipt/receipt
+ (spec/keys
+  :req-un
+  [:degree9.shopify.order.order.receipt/testcase
+   :degree9.shopify.order.order.receipt/authorization]))
+
+(spec/def :degree9.shopify.orders.order/fulfillment
+ (spec/keys
+  :req-un
+  [:degree9.shopify/id
+   :degree9.shopify/admin_graphql_api_id
+   :degree9.shopify/created_at
+   :degree9.shopify/updated_at
+   :degree9.shopify/client_details
+   :degree9.shopify.orders.order/order_id
+   :degree9.shopify.orders.order/line_items
+   :degree9.shopify.orders.order.fulfilment/status
+   :degree9.shopify.orders.order.fulfilment/service
+   :degree9.shopify.orders.order.fulfilment/tracking_company
+   :degree9.shopify.orders.order.fulfilment/shipment_status
+   :degree9.shopify.orders.order.fulfilment/location_id
+   :degree9.shopify.orders.order.fulfilment/tracking_number
+   :degree9.shopify.orders.order.fulfilment/tracking_numbers
+   :degree9.shopify.orders.order.fulfilment/tracking_url
+   :degree9.shopify.orders.order.fulfilment/tracking_urls
+   :degree9.shopify.order.order.fulfilment.receipt/receipt
+   :degree9.shopify.orders.order.fulfilment/name]))
+
+(spec/def :degree9.shopify.orders.order/fulfillments
+ (spec/coll-of
+  :degree9.shopify.orders.order/fulfillment))
+
 (spec/def :degree9.shopify.orders.order/order
  (spec/keys
   ; optional keys to support `fields` filtering
@@ -249,7 +301,12 @@
    :degree9.shopify.orders.order/order_status_url
 
    :degree9.shopify.orders.order/line_items
-   :degree9.shopify.orders.order/shipping_lines]))
+   :degree9.shopify.orders.order/shipping_lines
+
+   :degree9.shopify.orders.order/billing_address
+   :degree9.shopify.orders.order/shipping_address
+
+   :degree9.shopify.orders.order/fulfillments]))
 
 (spec/def :degree9.shopify.orders.order/orders
  (spec/coll-of

--- a/src/degree9/shopify/orders/order/spec.cljs
+++ b/src/degree9/shopify/orders/order/spec.cljs
@@ -45,26 +45,26 @@
 (spec/def :degree9.shopify.orders.order/confirmed boolean?)
 (spec/def :degree9.shopify.orders.order/total_discounts :degree9.shopify/monetary_amount)
 (spec/def :degree9.shopify.orders.order/total_line_items_price :degree9.shopify/monetary_amount)
-(spec/def :degree9.shopify.orders.order/cart_token :degree9.shopify/token)
+(spec/def :degree9.shopify.orders.order/cart_token (spec/nilable :degree9.shopify/token))
 (spec/def :degree9.shopify.orders.order/buyer_accepts_marketing boolean?)
 (spec/def :degree9.shopify.orders.order/name string?)
-(spec/def :degree9.shopify.orders.order/referring_site :degree9.shopify/url)
-(spec/def :degree9.shopify.orders.order/landing_site :degree9.shopify/url)
+(spec/def :degree9.shopify.orders.order/referring_site (spec/nilable :degree9.shopify/url))
+(spec/def :degree9.shopify.orders.order/landing_site (spec/nilable :degree9.shopify/url))
 (spec/def :degree9.shopify.orders.order/cancelled_at (spec/nilable :degree9.shopify/time))
 (spec/def :degree9.shopify.orders.order/cancel_reason (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/total_price_usd :degree9.shopify/monetary_amount)
-(spec/def :degree9.shopify.orders.order/checkout_token :degree9.shopify/token)
-(spec/def :degree9.shopify.orders.order/reference string?)
+(spec/def :degree9.shopify.orders.order/checkout_token (spec/nilable :degree9.shopify/token))
+(spec/def :degree9.shopify.orders.order/reference (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/user_id :degree9.shopify/id)
 (spec/def :degree9.shopify.orders.order/location_id :degree9.shopify/id)
-(spec/def :degree9.shopify.orders.order/source_identifier string?)
+(spec/def :degree9.shopify.orders.order/source_identifier (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/source_url (spec/nilable :degree9.shopify/url))
 (spec/def :degree9.shopify.orders.order/processed_at (spec/nilable :degree9.shopify/time))
 (spec/def :degree9.shopify.orders.order/device_id (spec/nilable :degree9.shopify/id))
 (spec/def :degree9.shopify.orders.order/customer_locale (spec/nilable :degree9.shopify/locale))
 (spec/def :degree9.shopify.orders.order/app_id (spec/nilable :degree9.shopify/id))
 (spec/def :degree9.shopify.orders.order/browser_ip (spec/nilable :degree9.shopify/ip))
-(spec/def :degree9.shopify.orders.order/landing_site_ref string?)
+(spec/def :degree9.shopify.orders.order/landing_site_ref (spec/nilable string?))
 (spec/def :degree9.shopify.orders.order/order_number :degree9.shopify/id)
 
 (spec/def :degree9.shopify.orders.order/note_attributes
@@ -77,7 +77,7 @@
   :degree9.shopify.orders.order/payment_gateway_name))
 
 (spec/def :degree9.shopify.orders.order/processing_method string?)
-(spec/def :degree9.shopify.orders.order/checkout_id :degree9.shopify/id)
+(spec/def :degree9.shopify.orders.order/checkout_id (spec/nilable :degree9.shopify/id))
 (spec/def :degree9.shopify.orders.order/source_name string?)
 (spec/def :degree9.shopify.orders.order/fulfillment_status (spec/nilable string?))
 
@@ -96,13 +96,13 @@
  (spec/coll-of
   :degree9.shopify.orders.order/tax_line))
 
-(spec/def :degree9.shopify.orders.order/contact_email :degree9.shopify/email)
+(spec/def :degree9.shopify.orders.order/contact_email (spec/nilable :degree9.shopify/email))
 (spec/def :degree9.shopify.orders.order/order_status_url :degree9.shopify/url)
 
 ; line items
 
 (spec/def :degree9.shopify.orders.order/variant_id :degree9.shopify.products.variant/id)
-(spec/def :degree9.shopify.orders.order/variant_title :degree9.shopify.products.variant/title)
+(spec/def :degree9.shopify.orders.order/variant_title (spec/nilable :degree9.shopify.products.variant/title))
 (spec/def :degree9.shopify.orders.order/product_id :degree9.shopify/id)
 (spec/def :degree9.shopify.orders.order/taxable boolean?)
 (spec/def :degree9.shopify.orders.order/gift_card boolean?)
@@ -233,6 +233,22 @@
  (spec/coll-of
   :degree9.shopify.orders.order/fulfillment))
 
+(spec/def :degree9.shopify.orders.order/refund
+ (spec/keys
+  :req-un
+  [:degree9.shopfy/id
+   :degree9.shopify/created_at
+   :degree9.shopify/created_at
+   :degree9.shopify/admin_graphql_api_id
+   :degree9.shopify.orders.order/order_id
+   :degree9.shopify.orders.order/user_id
+   :degree9.shopify.orders.order/processed_at
+   :degree9.shopify.orders.order.refund/note
+   :degree9.shopify.orders.order.refund/restock
+   :degree9.shopify.orders.order.refund/refund_line_items
+   :degree9.shopify.orders.order.refund/transactions
+   :degree9.shopify.orders.order.refund/order_adjustments]))
+
 (spec/def :degree9.shopify.orders.order/order
  (spec/keys
   ; optional keys to support `fields` filtering
@@ -242,10 +258,10 @@
    :degree9.shopify/created_at
    :degree9.shopify/updated_at
    :degree9.shopify/currency
-   :degree9.shopify/phone
    :degree9.shopify/tags
    :degree9.shopify/admin_graphql_api_id
 
+   :degree9.shopify.orders.order/phone
    :degree9.shopify.orders.order/closed_at
    :degree9.shopify.orders.order/number
    :degree9.shopify.orders.order/note
@@ -306,7 +322,11 @@
    :degree9.shopify.orders.order/billing_address
    :degree9.shopify.orders.order/shipping_address
 
-   :degree9.shopify.orders.order/fulfillments]))
+   :degree9.shopify.orders.order/fulfillments
+   :degree9.shopify.orders.order/refunds
+
+   :degree9.shopify.orders.order/payment_details
+   :degree9.shopify.orders.order/customer]))
 
 (spec/def :degree9.shopify.orders.order/orders
  (spec/coll-of

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -24,25 +24,44 @@
   :degree9.shopify.products.product/products
   maybe-products))
 
-; Fetch all products
-; @see https://help.shopify.com/en/api/reference/products/product#index
+; List all products
+;
+; Accepts many parameters for filtering, see Shopify docs
+;
+; # Examples
+;
+; ```
+; (list!
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product#index
+;
 (def list!
  (partial
   degree9.shopify.core/api!
-  :endpoint "/admin/products.json"))
+  :endpoint "product.list"))
 
-; Fetch a single product
-; @see https://help.shopify.com/en/api/reference/products/product#show
-(defn get!
- [id & {:keys [auth callback params]}]
- {:pre [(spec/valid? :degree9.shopify.products.product/id id)]
-  :post [(product? (:product %))]}
- (let [endpoint (str "/admin/products/" id ".json")]
-  (degree9.shopify.core/api!
-   :endpoint endpoint
-   :auth auth
-   :callback callback
-   :params params)))
+; Get a single product by ID
+;
+; Accepts a single optional parameter `fields` to filter returned fields.
+;
+; # Examples
+;
+; ```
+; (get! :params [1370204536875]) ; returns entire product object
+; (get! :params [1370204536875 {:fields [:title]}]) ; {:title "Test product A"}
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product#show
+;
+(def get!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "product.get"
+  :spec :degree9.shopify.products.product/product))
 
 ; Create a product
 ; @see https://help.shopify.com/en/api/reference/products/product#create

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -3,7 +3,8 @@
 (ns degree9.shopify.products.product.core
  (:require
   degree9.shopify.core
-  taoensso.timbre))
+  taoensso.timbre
+  degree9.shopify.products.product.spec))
 
 (defn product?
  [maybe-product]
@@ -25,14 +26,14 @@
 
 ; Fetch all products
 ; @see https://help.shopify.com/en/api/reference/products/product#index
-(def products!
+(def list!
  (partial
   degree9.shopify.core/api!
   :endpoint "/admin/products.json"))
 
 ; Fetch a single product
 ; @see https://help.shopify.com/en/api/reference/products/product#show
-(defn product!
+(defn get!
  [id & {:keys [auth callback params]}]
  {:pre [(spec/valid? :degree9.shopify.products.product/id id)]
   :post [(product? (:product %))]}
@@ -62,8 +63,19 @@
  (taoensso.timbre/error "delete! endpoint not implemented, see issue #11"))
 
 ; Fetch the total products count
-; @see https://help.shopify.com/en/api/reference/products/product#count
+;
+; # Examples
+;
+; ```
+; (count!) ; promise resolves to int
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product#count
+;
 (def count!
  (partial
   degree9.shopify.core/api!
-  :endpoint "/admin/products/count.json"))
+  :endpoint "product.count"
+  :spec :degree9.shopify.products.product/count))

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -80,7 +80,8 @@
 
 ; Update a product by ID
 ;
-; Accepts an ID and valid :degree9.shopify.products.product/product object.
+; Accepts an ID and valid :degree9.shopify.products.product/product.
+; Only modifies provided values.
 ;
 ; # Examples
 ;

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -1,9 +1,8 @@
 ; implements the REST API for the Product resource
-; @see https://help.shopify.com/en/api/reference/products/product
+; https://help.shopify.com/en/api/reference/products/product
 (ns degree9.shopify.products.product.core
  (:require
   degree9.shopify.core
-  taoensso.timbre
   degree9.shopify.products.product.spec))
 
 ; List all products
@@ -13,7 +12,9 @@
 ; # Examples
 ;
 ; ```
-; (list!
+; (list!) ; lists all products
+; (list! :params [{:fields [:id]}]) ; lists all product IDs
+; ```
 ;
 ; # References
 ;

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -33,7 +33,7 @@
 ; # Examples
 ;
 ; ```
-; (get! :params [1370204536875]) ; returns entire product object
+; (get! :params [1370204536875]) ; returns entire product
 ; (get! :params [1370204536875 {:fields [:title]}]) ; returns {:title "Test product A"}
 ; ```
 ;

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -1,0 +1,69 @@
+; implements the REST API for the Product resource
+; @see https://help.shopify.com/en/api/reference/products/product
+(ns degree9.shopify.products.product.core
+ (:require
+  degree9.shopify.core
+  taoensso.timbre))
+
+(defn product?
+ [maybe-product]
+ (spec/valid?
+  :degree9.shopify.products.product/product
+  maybe-product))
+
+(defn image?
+ [maybe-image]
+ (spec/valid?
+  :degree9.shopify.products.product/image
+  maybe-image))
+
+(defn products?
+ [maybe-products]
+ (spec/valid?
+  :degree9.shopify.products.product/products
+  maybe-products))
+
+; Fetch all products
+; @see https://help.shopify.com/en/api/reference/products/product#index
+(def products!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "/admin/products.json"))
+
+; Fetch a single product
+; @see https://help.shopify.com/en/api/reference/products/product#show
+(defn product!
+ [id & {:keys [auth callback params]}]
+ {:pre [(spec/valid? :degree9.shopify.products.product/id id)]
+  :post [(product? (:product %))]}
+ (let [endpoint (str "/admin/products/" id ".json")]
+  (degree9.shopify.core/api!
+   :endpoint endpoint
+   :auth auth
+   :callback callback
+   :params params)))
+
+; Create a product
+; @see https://help.shopify.com/en/api/reference/products/product#create
+(defn create!
+ [product-data]
+ (taoensso.timbre/error "create! endpoint not implemented, see issue #11"))
+
+; Update a product
+; @see https://help.shopify.com/en/api/reference/products/product#update
+(defn update!
+ [product-data]
+ (taoensso.timbre/error "update! endpoint not implemented, see issue #11"))
+
+; Delete a product
+; @see https://help.shopify.com/en/api/reference/products/product#destroy
+(defn delete!
+ [product-data]
+ (taoensso.timbre/error "delete! endpoint not implemented, see issue #11"))
+
+; Fetch the total products count
+; @see https://help.shopify.com/en/api/reference/products/product#count
+(def count!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "/admin/products/count.json"))

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -44,18 +44,26 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "product.get"
+  :input-spec :degree9.shopify/id
   :spec :degree9.shopify.products.product/product))
 
 ; Create a product
 ;
-; Accepts a valid :degree9.shopify.products.product/product object.
+; Accepts a valid :degree9.shopify.products.product/product object with a title.
+; Any missing values will have defaults merged in by Shopify.
+; Returns the newly created product.
 ;
 ; Requires additional app permissions to be set.
 ;
 ; # Examples
 ;
 ; ```
-; (create! :params [{:title "foo"}]) ; creates and returns new product with title "foo"
+; (create!) ; 400 error, need to provide a title!
+; (create! :params [{:body_html "foo"}] ; 422 error, need to provide a title!
+; ; creates and returns new product with title "foo"
+; (create! :params [{:title "foo"}])
+; ; creates and returns new product with title "foo" and body "bar"
+; (create! :params [{:title "foo" :body_html "bar"}])
 ; ```
 ;
 ; # References
@@ -65,19 +73,49 @@
 (def create!
  (partial
   degree9.shopify.core/api!
-  :endpoint "product.create"))
+  :endpoint "product.create"
+  :input-spec :degree9.shopify.products.product/product
+  :spec :degree9.shopify.products.product/product))
 
-; Update a product
-; @see https://help.shopify.com/en/api/reference/products/product#update
-(defn update!
- [product-data]
- (taoensso.timbre/error "update! endpoint not implemented, see issue #11"))
+; Update a product by ID
+;
+; Accepts an ID and valid :degree9.shopify.products.product/product object.
+;
+; # Examples
+;
+; ```
+; (update! :params [1393014931499 {:title "bar"}]) ; updates and returns product
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product#update
+;
+(def update!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "product.update"
+  :input-spec [:degree9.shopify/id :degree9.shopify.products.product/product]
+  :spec :degree9.shopify.products.product/product))
 
-; Delete a product
-; @see https://help.shopify.com/en/api/reference/products/product#destroy
-(defn delete!
- [product-data]
- (taoensso.timbre/error "delete! endpoint not implemented, see issue #11"))
+; Delete a product by ID
+;
+; # Examples
+;
+; ```
+; (delete! :params [1393013522475]) ; deletes product and returns `{}`
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product#destroy
+;
+(def delete!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "product.delete"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify/empty-api-response))
 
 ; Fetch the total products count
 ;

--- a/src/degree9/shopify/products/product/core.cljs
+++ b/src/degree9/shopify/products/product/core.cljs
@@ -6,24 +6,6 @@
   taoensso.timbre
   degree9.shopify.products.product.spec))
 
-(defn product?
- [maybe-product]
- (spec/valid?
-  :degree9.shopify.products.product/product
-  maybe-product))
-
-(defn image?
- [maybe-image]
- (spec/valid?
-  :degree9.shopify.products.product/image
-  maybe-image))
-
-(defn products?
- [maybe-products]
- (spec/valid?
-  :degree9.shopify.products.product/products
-  maybe-products))
-
 ; List all products
 ;
 ; Accepts many parameters for filtering, see Shopify docs
@@ -40,7 +22,8 @@
 (def list!
  (partial
   degree9.shopify.core/api!
-  :endpoint "product.list"))
+  :endpoint "product.list"
+  :spec :degree9.shopify.products.product/products))
 
 ; Get a single product by ID
 ;
@@ -50,7 +33,7 @@
 ;
 ; ```
 ; (get! :params [1370204536875]) ; returns entire product object
-; (get! :params [1370204536875 {:fields [:title]}]) ; {:title "Test product A"}
+; (get! :params [1370204536875 {:fields [:title]}]) ; returns {:title "Test product A"}
 ; ```
 ;
 ; # References
@@ -64,10 +47,25 @@
   :spec :degree9.shopify.products.product/product))
 
 ; Create a product
-; @see https://help.shopify.com/en/api/reference/products/product#create
-(defn create!
- [product-data]
- (taoensso.timbre/error "create! endpoint not implemented, see issue #11"))
+;
+; Accepts a valid :degree9.shopify.products.product/product object.
+;
+; Requires additional app permissions to be set.
+;
+; # Examples
+;
+; ```
+; (create! :params [{:title "foo"}]) ; creates and returns new product with title "foo"
+; ```
+;
+; # References
+;
+; -  https://help.shopify.com/en/api/reference/products/product#create
+;
+(def create!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "product.create"))
 
 ; Update a product
 ; @see https://help.shopify.com/en/api/reference/products/product#update
@@ -83,10 +81,13 @@
 
 ; Fetch the total products count
 ;
+; Accepts several parameters for filtering what is counted, see Shopify docs
+;
 ; # Examples
 ;
 ; ```
-; (count!) ; promise resolves to int
+; (count!) ; count all products
+; (count! :params [{:vendor :cannabit-dev}]) ; count all products for vendor
 ; ```
 ;
 ; # References
@@ -97,4 +98,4 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "product.count"
-  :spec :degree9.shopify.products.product/count))
+  :spec :degree9.shopify/count))

--- a/src/degree9/shopify/products/product/data.cljs
+++ b/src/degree9/shopify/products/product/data.cljs
@@ -1,0 +1,49 @@
+(ns degree9.shopify.products.product.data)
+
+(def product-example
+ {:vendor "cannabit-dev"
+  :tags ""
+  :admin_graphql_api_id "gid://shopify/Product/1370204536875"
+  :variants [{:admin_graphql_api_id "gid://shopify/ProductVariant/12891968536619"
+              :inventory_management "shopify"
+              :barcode ""
+              :product_id 1370204536875
+              :inventory_policy "deny"
+              :old_inventory_quantity 50
+              :weight_unit "kg"
+              :inventory_quantity 50
+              :title "Default Title"
+              :grams 0
+              :sku "TP-A"
+              :updated_at "2018-07-07T05:27:35-04:00"
+              :fulfillment_service "manual"
+              :compare_at_price nil
+              :weight 0
+              :inventory_item_id 13320318484523
+              :id 12891968536619
+              :option3 nil
+              :position 1
+              :option1 "Default Title"
+              :option2 nil
+              :taxable true
+              :price "100.00"
+              :image_id nil
+              :created_at "2018-07-07T05:26:28-04:00"
+              :requires_shipping true}]
+  :images []
+  :title "Test product A"
+  :product_type ""
+  :published_at "2018-07-07T05:25:36-04:00"
+  :updated_at "2018-07-07T05:31:17-04:00"
+  :id 1370204536875
+  :handle "test-product-a"
+  :body_html "some description"
+  :image nil
+  :options [{:id 1932968394795
+             :product_id 1370204536875
+             :name "Title"
+             :position 1
+             :values ["Default Title"]}]
+  :template_suffix nil
+  :published_scope "global"
+  :created_at "2018-07-07T05:26:28-04:00"})

--- a/src/degree9/shopify/products/product/spec.cljs
+++ b/src/degree9/shopify/products/product/spec.cljs
@@ -1,5 +1,112 @@
 (ns degree9.shopify.products.product.spec
  (:require
+  degree9.shopify.spec
   [cljs.spec.alpha :as spec]))
 
 (spec/def :degree9.shopify.products.product/count int?)
+
+(spec/def :degree9.shopify.products.product.variant/inventory_management string?)
+(spec/def :degree9.shopify.products.product.variant/barcode string?)
+(spec/def :degree9.shopify.products.product.variant/product_id :degree9.shopify/id)
+(spec/def :degree9.shopify.products.product.variant/inventory_policy string?)
+(spec/def :degree9.shopify.products.product.variant/inventory_quantity int?)
+(spec/def :degree9.shopify.products.product.variant/old_inventory_quantity :degree9.shopify.products.product.variant/inventory_quantity)
+(spec/def :degree9.shopify.products.product.variant/weight_unit string?)
+(spec/def :degree9.shopify.products.product.variant/title string?)
+(spec/def :degree9.shopify.products.product.variant/grams number?)
+(spec/def :degree9.shopify.products.product.variant/sku string?)
+(spec/def :degree9.shopify.products.product.variant/fulfillment_service string?)
+(spec/def :degree9.shopify.products.product.variant/compare_at_price (spec/nilable :degree9.shopify/price))
+(spec/def :degree9.shopify.products.product.variant/weight number?)
+(spec/def :degree9.shopify.products.product.variant/inventory_item_id :degree9.shopify/id)
+(spec/def :degree9.shopify.products.product.variant/position int)
+(spec/def :degree9.shopify.products.product.variant/option1 (spec/nilable string?))
+(spec/def :degree9.shopify.products.product.variant/option2 (spec/nilable string?))
+(spec/def :degree9.shopify.products.product.variant/option3 (spec/nilable string?))
+(spec/def :degree9.shopify.products.product.variant/taxable boolean?)
+(spec/def :degree9.shopify.products.product.variant/image_id (spec/nilable :degree9.shopify/id))
+(spec/def :degree9.shopify.products.product.variant/requires_shipping boolean?)
+
+(spec/def :degree9.shopify.products.product.variant/variant
+ (spec/keys
+  :req-un
+  [:degree9.shopify/admin_graphql_api_id
+   :degree9.shopify/created_at
+   :degree9.shopify/updated_at
+   :degree9.shopify/price
+   :degree9.shopify/title
+
+   :degree9.shopify.products.product.variant/product_id
+   :degree9.shopify.products.product.variant/inventory_management
+   :degree9.shopify.products.product.variant/barcode
+   :degree9.shopify.products.product.variant/inventory_policy
+   :degree9.shopify.products.product.variant/inventory_quantity
+   :degree9.shopify.products.product.variant/old_inventory_quantity
+   :degree9.shopify.products.product.variant/weight_unit
+   :degree9.shopify.products.product.variant/grams
+   :degree9.shopify.products.product.variant/sku
+   :degree9.shopify.products.product.variant/fulfillment_service
+   :degree9.shopify.products.product.variant/compare_at_price
+   :degree9.shopify.products.product.variant/weight
+   :degree9.shopify.products.product.variant/inventory_item_id
+   :degree9.shopify.products.product.variant/position
+   :degree9.shopify.products.product.variant/option1
+   :degree9.shopify.products.product.variant/option2
+   :degree9.shopify.products.product.variant/option3
+   :degree9.shopify.products.product.variant/taxable
+   :degree9.shopify.products.product.variant/image_id
+   :degree9.shopify.products.product.variant/requires_shipping]))
+
+(spec/def :degree9.shopify.products.product.option/name :degree9.shopify/title)
+(spec/def :degree9.shopify.products.product.option/value string?)
+(spec/def :degree9.shopify.products.product.option/values
+ (spec/coll-of
+  :degree9.shopify.products.product.option/value))
+(spec/def :degree9.shopify.products.product.options/option
+ (spec/keys
+  :req-un
+  [:degree9.shopify/id
+   :degree9.shopify/position
+
+   :degree9.shopify.products.product.variant/product_id
+   :degree9.shopify.products.product.option/name
+   :degree9.shopify.products.product.option/values]))
+(spec/def :degree9.shopify.products.product.options/options
+ (spec/coll-of
+  :degree9.shopify.products.product.options/option))
+
+; @TODO what does an image look like?
+(spec/def :degree9.shopify.products.product/image (spec/nilable any?))
+
+(spec/def :degree9.shopify.products.product/vendor string?)
+(spec/def :degree9.shopify.products.product/tags string?)
+(spec/def :degree9.shopify.products.product/variants
+ (spec/coll-of :degree9.shopify.products.product.variant/variant))
+(spec/def :degree9.shopify.products.product/images
+ (spec/coll-of :degree9.shopify.products.product/image))
+(spec/def :degree9.shopify.products.product/product_type string?)
+(spec/def :degree9.shopify.products.product/handle string?)
+(spec/def :degree9.shopify.products.product/body_html string?)
+(spec/def :degree9.shopify.products.product/template_suffix (spec/nilable string?))
+(spec/def :degree9.shopify.products.product/published_scope string?)
+
+(spec/def :degree9.shopify.products.product/product
+ (spec/keys
+  :opt-un
+  [:degree9.shopify/admin_graphql_api_id
+   :degree9.shopify/title
+   :degree9.shopify/created_at
+   :degree9.shopify/updated_at
+   :degree9.shopify/published_at
+   :degree9.shopify/id
+
+   :degree9.shopify.products.product/vendor
+   :degree9.shopify.products.product/tags
+   :degree9.shopify.products.product.variant/variants
+   :degree9.shopify.products.product/images
+   :degree9.shopify.products.product/image
+   :degree9.shopify.products.product/handle
+   :degree9.shopify.products.product/body_html
+   :degree9.shopify.products.product.options/options
+   :degree9.shopify.products.product/template_suffix
+   :degree9.shopify.products.product/published_scope]))

--- a/src/degree9/shopify/products/product/spec.cljs
+++ b/src/degree9/shopify/products/product/spec.cljs
@@ -3,8 +3,6 @@
   degree9.shopify.spec
   [cljs.spec.alpha :as spec]))
 
-(spec/def :degree9.shopify.products.product/count int?)
-
 (spec/def :degree9.shopify.products.product.variant/inventory_management string?)
 (spec/def :degree9.shopify.products.product.variant/barcode string?)
 (spec/def :degree9.shopify.products.product.variant/product_id :degree9.shopify/id)

--- a/src/degree9/shopify/products/product/spec.cljs
+++ b/src/degree9/shopify/products/product/spec.cljs
@@ -1,0 +1,5 @@
+(ns degree9.shopify.products.product.spec
+ (:require
+  [cljs.spec.alpha :as spec]))
+
+(spec/def :degree9.shopify.products.product/count int?)

--- a/src/degree9/shopify/products/product/spec.cljs
+++ b/src/degree9/shopify/products/product/spec.cljs
@@ -25,8 +25,6 @@
 ; @TODO what does an image look like?
 (spec/def :degree9.shopify.products.product/image (spec/nilable any?))
 
-(spec/def :degree9.shopify.products.product/vendor string?)
-(spec/def :degree9.shopify.products.product/tags string?)
 (spec/def :degree9.shopify.products.product/images
  (spec/coll-of :degree9.shopify.products.product/image))
 (spec/def :degree9.shopify.products.product/product_type string?)
@@ -45,11 +43,11 @@
    :degree9.shopify/updated_at
    :degree9.shopify/published_at
    :degree9.shopify/id
+   :degree9.shopify/tags
+   :degree9.shopify/vendor
 
    :degree9.shopify.products.variant/variants
 
-   :degree9.shopify.products.product/vendor
-   :degree9.shopify.products.product/tags
    :degree9.shopify.products.product/images
    :degree9.shopify.products.product/image
    :degree9.shopify.products.product/handle

--- a/src/degree9/shopify/products/product/spec.cljs
+++ b/src/degree9/shopify/products/product/spec.cljs
@@ -1,59 +1,8 @@
 (ns degree9.shopify.products.product.spec
  (:require
+  degree9.shopify.products.variant.spec
   degree9.shopify.spec
   [cljs.spec.alpha :as spec]))
-
-(spec/def :degree9.shopify.products.product.variant/inventory_management string?)
-(spec/def :degree9.shopify.products.product.variant/barcode string?)
-(spec/def :degree9.shopify.products.product.variant/product_id :degree9.shopify/id)
-(spec/def :degree9.shopify.products.product.variant/inventory_policy string?)
-(spec/def :degree9.shopify.products.product.variant/inventory_quantity int?)
-(spec/def :degree9.shopify.products.product.variant/old_inventory_quantity :degree9.shopify.products.product.variant/inventory_quantity)
-(spec/def :degree9.shopify.products.product.variant/weight_unit string?)
-(spec/def :degree9.shopify.products.product.variant/title string?)
-(spec/def :degree9.shopify.products.product.variant/grams number?)
-(spec/def :degree9.shopify.products.product.variant/sku string?)
-(spec/def :degree9.shopify.products.product.variant/fulfillment_service string?)
-(spec/def :degree9.shopify.products.product.variant/compare_at_price (spec/nilable :degree9.shopify/price))
-(spec/def :degree9.shopify.products.product.variant/weight number?)
-(spec/def :degree9.shopify.products.product.variant/inventory_item_id :degree9.shopify/id)
-(spec/def :degree9.shopify.products.product.variant/position int)
-(spec/def :degree9.shopify.products.product.variant/option1 (spec/nilable string?))
-(spec/def :degree9.shopify.products.product.variant/option2 (spec/nilable string?))
-(spec/def :degree9.shopify.products.product.variant/option3 (spec/nilable string?))
-(spec/def :degree9.shopify.products.product.variant/taxable boolean?)
-(spec/def :degree9.shopify.products.product.variant/image_id (spec/nilable :degree9.shopify/id))
-(spec/def :degree9.shopify.products.product.variant/requires_shipping boolean?)
-
-(spec/def :degree9.shopify.products.product.variant/variant
- (spec/keys
-  :req-un
-  [:degree9.shopify/admin_graphql_api_id
-   :degree9.shopify/created_at
-   :degree9.shopify/updated_at
-   :degree9.shopify/price
-   :degree9.shopify/title
-
-   :degree9.shopify.products.product.variant/product_id
-   :degree9.shopify.products.product.variant/inventory_management
-   :degree9.shopify.products.product.variant/barcode
-   :degree9.shopify.products.product.variant/inventory_policy
-   :degree9.shopify.products.product.variant/inventory_quantity
-   :degree9.shopify.products.product.variant/old_inventory_quantity
-   :degree9.shopify.products.product.variant/weight_unit
-   :degree9.shopify.products.product.variant/grams
-   :degree9.shopify.products.product.variant/sku
-   :degree9.shopify.products.product.variant/fulfillment_service
-   :degree9.shopify.products.product.variant/compare_at_price
-   :degree9.shopify.products.product.variant/weight
-   :degree9.shopify.products.product.variant/inventory_item_id
-   :degree9.shopify.products.product.variant/position
-   :degree9.shopify.products.product.variant/option1
-   :degree9.shopify.products.product.variant/option2
-   :degree9.shopify.products.product.variant/option3
-   :degree9.shopify.products.product.variant/taxable
-   :degree9.shopify.products.product.variant/image_id
-   :degree9.shopify.products.product.variant/requires_shipping]))
 
 (spec/def :degree9.shopify.products.product.option/name :degree9.shopify/title)
 (spec/def :degree9.shopify.products.product.option/value string?)
@@ -66,7 +15,7 @@
   [:degree9.shopify/id
    :degree9.shopify/position
 
-   :degree9.shopify.products.product.variant/product_id
+   :degree9.shopify.products.variant/product_id
    :degree9.shopify.products.product.option/name
    :degree9.shopify.products.product.option/values]))
 (spec/def :degree9.shopify.products.product.options/options
@@ -78,8 +27,6 @@
 
 (spec/def :degree9.shopify.products.product/vendor string?)
 (spec/def :degree9.shopify.products.product/tags string?)
-(spec/def :degree9.shopify.products.product/variants
- (spec/coll-of :degree9.shopify.products.product.variant/variant))
 (spec/def :degree9.shopify.products.product/images
  (spec/coll-of :degree9.shopify.products.product/image))
 (spec/def :degree9.shopify.products.product/product_type string?)
@@ -90,6 +37,7 @@
 
 (spec/def :degree9.shopify.products.product/product
  (spec/keys
+  ; keys are optional to support `fields` filter in api calls
   :opt-un
   [:degree9.shopify/admin_graphql_api_id
    :degree9.shopify/title
@@ -98,9 +46,10 @@
    :degree9.shopify/published_at
    :degree9.shopify/id
 
+   :degree9.shopify.products.variant/variants
+
    :degree9.shopify.products.product/vendor
    :degree9.shopify.products.product/tags
-   :degree9.shopify.products.product.variant/variants
    :degree9.shopify.products.product/images
    :degree9.shopify.products.product/image
    :degree9.shopify.products.product/handle

--- a/src/degree9/shopify/products/variant/core.cljs
+++ b/src/degree9/shopify/products/variant/core.cljs
@@ -44,3 +44,25 @@
   :endpoint "productVariant.count"
   :input-spec :degree9.shopify/id
   :spec :degree9.shopify/count))
+
+; Get a single variant by variant ID
+;
+; Accepts a single `fields` param to filter the values returned.
+;
+; # Examples
+;
+; ```
+; (get! :params [12891968536619]) ; returns variant 12891968536619
+; (get! :params [12891968536619 {:fields [:id]}]) ; returns {:id 12891968536619}
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product_variant#show
+;
+(def get!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "productVariant.get"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.products.variant/variant))

--- a/src/degree9/shopify/products/variant/core.cljs
+++ b/src/degree9/shopify/products/variant/core.cljs
@@ -25,3 +25,22 @@
   :endpoint "productVariant.list"
   :input-spec :degree9.shopify/id
   :spec :degree9.shopify.products.variant/variants))
+
+; Count all variants for a single product ID
+;
+; # Examples
+;
+; ```
+; (count! :params [1370204536875]) ; count of variants for product 1370204536875
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product_variant#count
+;
+(def count!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "productVariant.count"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify/count))

--- a/src/degree9/shopify/products/variant/core.cljs
+++ b/src/degree9/shopify/products/variant/core.cljs
@@ -23,7 +23,7 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "productVariant.list"
-  :input-spec :degree9.shopify/id
+  :input-spec :degree9.shopify.products.variant/product_id
   :spec :degree9.shopify.products.variant/variants))
 
 ; Count all variants for a single product ID
@@ -42,7 +42,7 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "productVariant.count"
-  :input-spec :degree9.shopify/id
+  :input-spec :degree9.shopify.products.variant/product_id
   :spec :degree9.shopify/count))
 
 ; Get a single variant by variant ID
@@ -97,6 +97,7 @@
 ; Update a variant by variant ID
 ;
 ; Accepts a variant ID and valid :degree9.shopify.products.variant/variant.
+; Only modifies provided values.
 ;
 ; # Examples
 ;
@@ -112,5 +113,25 @@
  (partial
   degree9.shopify.core/api!
   :endpoint "productVariant.update"
-  :input-spec [:degree9.shopify.products.variant/product_id :degree9.shopify.products.variant/variant]
+  :input-spec [:degree9.shopify/id :degree9.shopify.products.variant/variant]
   :spec :degree9.shopify.products.variant/variant))
+
+; Delete a variant by product ID and variant ID
+;
+; # Examples
+;
+; ```
+; ; deletes variant 13053395730475 from product 1370204536875 and returns `{}`
+; (delete! :params [1370204536875 13053395730475])
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product_variant#destroy
+;
+(def delete!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "productVariant.delete"
+  :input-spec [:degree9.shopify.products.variant/product_id :degree9.shopify/id]
+  :spec :degree9.shopify/empty-api-response))

--- a/src/degree9/shopify/products/variant/core.cljs
+++ b/src/degree9/shopify/products/variant/core.cljs
@@ -93,3 +93,24 @@
   :endpoint "productVariant.create"
   :input-spec [:degree9.shopify.products.variant/product_id :degree9.shopify.products.variant/variant]
   :spec :degree9.shopify.products.variant/variant))
+
+; Update a variant by variant ID
+;
+; Accepts a variant ID and valid :degree9.shopify.products.variant/variant.
+;
+; # Examples
+;
+; ```
+; (update! :params [13053346775083 {:option1 "flowers"}]) ; updates and returns variant 13053346775083
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product_variant#update
+;
+(def update!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "productVariant.update"
+  :input-spec [:degree9.shopify.products.variant/product_id :degree9.shopify.products.variant/variant]
+  :spec :degree9.shopify.products.variant/variant))

--- a/src/degree9/shopify/products/variant/core.cljs
+++ b/src/degree9/shopify/products/variant/core.cljs
@@ -66,3 +66,30 @@
   :endpoint "productVariant.get"
   :input-spec :degree9.shopify/id
   :spec :degree9.shopify.products.variant/variant))
+
+; Create a variant for a given product ID
+;
+; Accepts a product ID and valid :degree9.shopify.products.variant/variant.
+; An option string (1, 2 or 3) is required.
+; Option strings must be globally unique across all variants for the product or
+; the API will error with 422.
+;
+; # Examples
+;
+; ```
+; (create! :params [1370204536875 {:price "50.00"}]) ; 422 error, need to provide option1!
+; ; create and return new variant for product 1370204536875
+; (create! :params [1370204536875 {:option1 "yellow"}])
+; (create! :params [1370204536875 {:option1 "yellow"}]) ; 422 error, duplicate option!
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product_variant#create
+;
+(def create!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "productVariant.create"
+  :input-spec [:degree9.shopify.products.variant/product_id :degree9.shopify.products.variant/variant]
+  :spec :degree9.shopify.products.variant/variant))

--- a/src/degree9/shopify/products/variant/core.cljs
+++ b/src/degree9/shopify/products/variant/core.cljs
@@ -1,0 +1,27 @@
+; implements REST API for products Variant resource
+; https://help.shopify.com/en/api/reference/products/product_variant
+(ns degree9.shopify.products.variant.core
+ (:require
+  degree9.shopify.core))
+
+; List all variants for a single product ID
+;
+; Accepts pagination and `fields` parameters, see Shopify docs
+;
+; # Examples
+;
+; ```
+; (list! :params [1370204536875]) ; lists all variants for product 1370204536875
+; (list! :params [1370204536875 {:fields [:id]}]) ; lists all variants' ids
+; ```
+;
+; # References
+;
+; - https://help.shopify.com/en/api/reference/products/product#index
+;
+(def list!
+ (partial
+  degree9.shopify.core/api!
+  :endpoint "productVariant.list"
+  :input-spec :degree9.shopify/id
+  :spec :degree9.shopify.products.variant/variants))

--- a/src/degree9/shopify/products/variant/spec.cljs
+++ b/src/degree9/shopify/products/variant/spec.cljs
@@ -4,7 +4,7 @@
   [cljs.spec.alpha :as spec]))
 
 (spec/def :degree9.shopify.products.variant/inventory_management (spec/nilable string?))
-(spec/def :degree9.shopify.products.variant/barcode string?)
+(spec/def :degree9.shopify.products.variant/barcode (spec/nilable string?))
 (spec/def :degree9.shopify.products.variant/product_id :degree9.shopify/id)
 (spec/def :degree9.shopify.products.variant/inventory_policy string?)
 (spec/def :degree9.shopify.products.variant/inventory_quantity int?)

--- a/src/degree9/shopify/products/variant/spec.cljs
+++ b/src/degree9/shopify/products/variant/spec.cljs
@@ -3,6 +3,7 @@
   degree9.shopify.spec
   [cljs.spec.alpha :as spec]))
 
+(spec/def :degree9.shopify.products.variant/id :degree9.shopify/id)
 (spec/def :degree9.shopify.products.variant/inventory_management (spec/nilable string?))
 (spec/def :degree9.shopify.products.variant/barcode (spec/nilable string?))
 (spec/def :degree9.shopify.products.variant/product_id :degree9.shopify/id)
@@ -12,10 +13,8 @@
 (spec/def :degree9.shopify.products.variant/weight_unit string?)
 (spec/def :degree9.shopify.products.variant/title string?)
 (spec/def :degree9.shopify.products.variant/grams number?)
-(spec/def :degree9.shopify.products.variant/sku string?)
-(spec/def :degree9.shopify.products.variant/fulfillment_service string?)
-(spec/def :degree9.shopify.products.variant/compare_at_price (spec/nilable :degree9.shopify/price))
-(spec/def :degree9.shopify.products.variant/weight number?)
+(spec/def :degree9.shopify.products.variant/sku :degree9.shopify/sku)
+(spec/def :degree9.shopify.products.variant/compare_at_price (spec/nilable :degree9.shopify/monetary_amount))
 (spec/def :degree9.shopify.products.variant/inventory_item_id :degree9.shopify/id)
 (spec/def :degree9.shopify.products.variant/position int)
 (spec/def :degree9.shopify.products.variant/option1 (spec/nilable string?))
@@ -32,9 +31,12 @@
   [:degree9.shopify/admin_graphql_api_id
    :degree9.shopify/created_at
    :degree9.shopify/updated_at
-   :degree9.shopify/price
+   :degree9.shopify/monetary_amount
    :degree9.shopify/title
+   :degree9.shopify/weight
+   :degree9.shopify/fulfillment_service
 
+   :degree9.shopify.products.variant/id
    :degree9.shopify.products.variant/product_id
    :degree9.shopify.products.variant/inventory_management
    :degree9.shopify.products.variant/barcode
@@ -44,9 +46,7 @@
    :degree9.shopify.products.variant/weight_unit
    :degree9.shopify.products.variant/grams
    :degree9.shopify.products.variant/sku
-   :degree9.shopify.products.variant/fulfillment_service
    :degree9.shopify.products.variant/compare_at_price
-   :degree9.shopify.products.variant/weight
    :degree9.shopify.products.variant/inventory_item_id
    :degree9.shopify.products.variant/position
    :degree9.shopify.products.variant/option1

--- a/src/degree9/shopify/products/variant/spec.cljs
+++ b/src/degree9/shopify/products/variant/spec.cljs
@@ -1,0 +1,60 @@
+(ns degree9.shopify.products.variant.spec
+ (:require
+  degree9.shopify.spec
+  [cljs.spec.alpha :as spec]))
+
+(spec/def :degree9.shopify.products.variant/inventory_management string?)
+(spec/def :degree9.shopify.products.variant/barcode string?)
+(spec/def :degree9.shopify.products.variant/product_id :degree9.shopify/id)
+(spec/def :degree9.shopify.products.variant/inventory_policy string?)
+(spec/def :degree9.shopify.products.variant/inventory_quantity int?)
+(spec/def :degree9.shopify.products.variant/old_inventory_quantity :degree9.shopify.products.variant/inventory_quantity)
+(spec/def :degree9.shopify.products.variant/weight_unit string?)
+(spec/def :degree9.shopify.products.variant/title string?)
+(spec/def :degree9.shopify.products.variant/grams number?)
+(spec/def :degree9.shopify.products.variant/sku string?)
+(spec/def :degree9.shopify.products.variant/fulfillment_service string?)
+(spec/def :degree9.shopify.products.variant/compare_at_price (spec/nilable :degree9.shopify/price))
+(spec/def :degree9.shopify.products.variant/weight number?)
+(spec/def :degree9.shopify.products.variant/inventory_item_id :degree9.shopify/id)
+(spec/def :degree9.shopify.products.variant/position int)
+(spec/def :degree9.shopify.products.variant/option1 (spec/nilable string?))
+(spec/def :degree9.shopify.products.variant/option2 (spec/nilable string?))
+(spec/def :degree9.shopify.products.variant/option3 (spec/nilable string?))
+(spec/def :degree9.shopify.products.variant/taxable boolean?)
+(spec/def :degree9.shopify.products.variant/image_id (spec/nilable :degree9.shopify/id))
+(spec/def :degree9.shopify.products.variant/requires_shipping boolean?)
+
+(spec/def :degree9.shopify.products.variant/variant
+ (spec/keys
+  ; keys are optional to support `fields` filter in API calls
+  :opt-un
+  [:degree9.shopify/admin_graphql_api_id
+   :degree9.shopify/created_at
+   :degree9.shopify/updated_at
+   :degree9.shopify/price
+   :degree9.shopify/title
+
+   :degree9.shopify.products.variant/product_id
+   :degree9.shopify.products.variant/inventory_management
+   :degree9.shopify.products.variant/barcode
+   :degree9.shopify.products.variant/inventory_policy
+   :degree9.shopify.products.variant/inventory_quantity
+   :degree9.shopify.products.variant/old_inventory_quantity
+   :degree9.shopify.products.variant/weight_unit
+   :degree9.shopify.products.variant/grams
+   :degree9.shopify.products.variant/sku
+   :degree9.shopify.products.variant/fulfillment_service
+   :degree9.shopify.products.variant/compare_at_price
+   :degree9.shopify.products.variant/weight
+   :degree9.shopify.products.variant/inventory_item_id
+   :degree9.shopify.products.variant/position
+   :degree9.shopify.products.variant/option1
+   :degree9.shopify.products.variant/option2
+   :degree9.shopify.products.variant/option3
+   :degree9.shopify.products.variant/taxable
+   :degree9.shopify.products.variant/image_id
+   :degree9.shopify.products.variant/requires_shipping]))
+
+(spec/def :degree9.shopify.products.variant/variants
+ (spec/coll-of :degree9.shopify.products.variant/variant))

--- a/src/degree9/shopify/products/variant/spec.cljs
+++ b/src/degree9/shopify/products/variant/spec.cljs
@@ -3,7 +3,7 @@
   degree9.shopify.spec
   [cljs.spec.alpha :as spec]))
 
-(spec/def :degree9.shopify.products.variant/inventory_management string?)
+(spec/def :degree9.shopify.products.variant/inventory_management (spec/nilable string?))
 (spec/def :degree9.shopify.products.variant/barcode string?)
 (spec/def :degree9.shopify.products.variant/product_id :degree9.shopify/id)
 (spec/def :degree9.shopify.products.variant/inventory_policy string?)

--- a/src/degree9/shopify/spec.cljs
+++ b/src/degree9/shopify/spec.cljs
@@ -22,6 +22,8 @@
 
 ; system state values
 (spec/def :degree9.shopify/position int?)
+(spec/def :degree9.shopify/empty-api-response
+ (spec/and map? empty?))
 
 ; counts are ints
 (spec/def :degree9.shopify/count nat-int?)

--- a/src/degree9/shopify/spec.cljs
+++ b/src/degree9/shopify/spec.cljs
@@ -22,3 +22,6 @@
 
 ; system state values
 (spec/def :degree9.shopify/position int?)
+
+; counts are ints
+(spec/def :degree9.shopify/count nat-int?)

--- a/src/degree9/shopify/spec.cljs
+++ b/src/degree9/shopify/spec.cljs
@@ -1,0 +1,24 @@
+(ns degree9.shopify.spec
+ (:require
+  [cljs.spec.alpha :as spec]))
+
+; all gid:// are strings
+(spec/def :degree9.shopify/admin_graphql_api_id string?)
+
+; all IDs are integers
+(spec/def :degree9.shopify/id pos-int?)
+
+; all times are iso8601
+(spec/def :degree9.shopify/time string?)
+(spec/def :degree9.shopify/created_at :degree9.shopify/time)
+(spec/def :degree9.shopify/updated_at :degree9.shopify/time)
+(spec/def :degree9.shopify/published_at :degree9.shopify/time)
+
+; prices are decimal strings
+(spec/def :degree9.shopify/price string?)
+
+; titles are strings
+(spec/def :degree9.shopify/title string?)
+
+; system state values
+(spec/def :degree9.shopify/position int?)

--- a/src/degree9/shopify/spec.cljs
+++ b/src/degree9/shopify/spec.cljs
@@ -72,3 +72,56 @@
   :req-un
   [:degree9.shopify.attribute/name
    :degree9.shopify.attribute/value]))
+
+; addresses have several fields
+(spec/def :degree9.shopify.address/first_name string?)
+(spec/def :degree9.shopify.address/last_name string?)
+(spec/def :degree9.shopify.address/name string?)
+(spec/def :degree9.shopify.address/address1 string?)
+(spec/def :degree9.shopify.address/address2 string?)
+(spec/def :degree9.shopify.address/phone :degree9.shopify/phone)
+(spec/def :degree9.shopify.address/city string?)
+(spec/def :degree9.shopify.address/zip string?)
+(spec/def :degree9.shopify.address/province string?)
+(spec/def :degree9.shopify.address/province_code string?)
+(spec/def :degree9.shopify.address/country string?)
+(spec/def :degree9.shopify.address/country_code string?)
+(spec/def :degree9.shopify.address/company (spec/nilable string?))
+(spec/def :degree9.shopify.address/latitude number?)
+(spec/def :degree9.shopify.address/longitude number?)
+
+(spec/def :degree9.shopify.address/address
+ (spec/keys
+  :req-un
+  [:degree9.shopify.address/first_name
+   :degree9.shopify.address/last_name
+   :degree9.shopify.address/name
+   :degree9.shopify.address/address1
+   :degree9.shopify.address/address2
+   :degree9.shopify.address/phone
+   :degree9.shopify.address/city
+   :degree9.shopify.address/zip
+   :degree9.shopify.address/province
+   :degree9.shopify.address/province_code
+   :degree9.shopify.address/country
+   :degree9.shopify.address/country_code
+   :degree9.shopify.address/company
+   :degree9.shopify.address/latitude
+   :degree9.shopify.address/longitude]))
+
+; client details has several fields
+(spec/def :degree9.shopify/browser_ip :degree9.shopify/ip)
+(spec/def :degree9.shopify/accept_language (spec/nilable string?))
+(spec/def :degree9.shopify/user_agent (spec/nilable string?))
+(spec/def :degree9.shopify/session_hash (spec/nilable string?))
+(spec/def :degree9.shopify/browser_width (spec/nilable string?))
+(spec/def :degree9.shopify/browser_height (spec/nilable string?))
+(spec/def :degree9.shopify/client_details
+ (spec/keys
+  :req-un
+  [:degree9.shopify/browser_ip
+   :degree9.shopify/accept_language
+   :degree9.shopify/user_agent
+   :degree9.shopify/session_hash
+   :degree9.shopify/browser_width
+   :degree9.shopify/browser_height]))

--- a/src/degree9/shopify/spec.cljs
+++ b/src/degree9/shopify/spec.cljs
@@ -14,16 +14,61 @@
 (spec/def :degree9.shopify/updated_at :degree9.shopify/time)
 (spec/def :degree9.shopify/published_at :degree9.shopify/time)
 
-; prices are decimal strings
-(spec/def :degree9.shopify/price string?)
+; weights are numbers
+(spec/def :degree9.shopify/weight number?)
+
+; money
+(spec/def :degree9.shopify/monetary_amount string?)
+(spec/def :degree9.shopify/price :degree9.shopify/monetary_amount)
+(spec/def :degree9.shopify/currency string?)
 
 ; titles are strings
 (spec/def :degree9.shopify/title string?)
+
+; skus are strings
+(spec/def :degree9.shopify/sku string?)
+
+; tags are strings
+(spec/def :degree9.shopify/tags string?)
+
+; vendors are strings
+(spec/def :degree9.shopify/vendor string?)
+
+; fulfillment services are strings
+(spec/def :degree9.shopify/fulfillment_service string?)
+
+; emails are strings
+(spec/def :degree9.shopify/email string?)
+
+; urls are strings
+(spec/def :degree9.shopify/url string?)
+
+; phone numbers are strings
+(spec/def :degree9.shopify/phone string?)
+
+; quantities are numbers
+(spec/def :degree9.shopify/quantity nat-int?)
+
+; i18n
+(spec/def :degree9.shopify/locale string?)
+
+; IPs are strings
+(spec/def :degree9.shopify/ip string?)
 
 ; system state values
 (spec/def :degree9.shopify/position int?)
 (spec/def :degree9.shopify/empty-api-response
  (spec/and map? empty?))
+(spec/def :degree9.shopify/token string?)
 
 ; counts are ints
 (spec/def :degree9.shopify/count nat-int?)
+
+; attributes are name/value pairs
+(spec/def :degree9.shopify.attribute/name string?)
+(spec/def :degree9.shopify.attribute/value string?)
+(spec/def :degree9.shopify/attribute
+ (spec/keys
+  :req-un
+  [:degree9.shopify.attribute/name
+   :degree9.shopify.attribute/value]))


### PR DESCRIPTION
fixes #9 

- swaps out the npm package for request with an official shopify sdk
- fixes bug in missing cuerdas dependency
- implements specs and logging for api! to avoid cryptic upstream errors
- implements crud endpoints for products and variants
- implements spec for products and variants
- migrate locations to npm package endpoint formats
- implements crud/workflow endpoints for orders
- implements spec for orders

note that the orders spec is largely an amalgamation of other specs, like refunds, customer, addresses, etc. i did a quick pass over this, dumping it all into the order spec namespace, expecting it to be fleshed out more and refactored over time.